### PR TITLE
Ajout de l'extension lieuDit

### DIFF
--- a/input/fsh/extensions/AsLieuDitExtension.fsh
+++ b/input/fsh/extensions/AsLieuDitExtension.fsh
@@ -1,5 +1,5 @@
 Extension: 		AsLieuDit
-Id: 			as-ext-data-trace
+Id: 			as-ext-lieu-dit
 Title:			"AS Lieu Dit Extension"
 Description:	"Extension créée dans le cadre de l'Annuaire Santé pour indiquer le lieu dit"
 * . ^short = "DataTrace : Permet d'indiquer le lieu dit"

--- a/input/fsh/extensions/AsLieuDitExtension.fsh
+++ b/input/fsh/extensions/AsLieuDitExtension.fsh
@@ -1,0 +1,11 @@
+Extension: 		AsLieuDit
+Id: 			as-ext-data-trace
+Title:			"AS Lieu Dit Extension"
+Description:	"Extension créée dans le cadre de l'Annuaire Santé pour indiquer le lieu dit"
+* . ^short = "DataTrace : Permet d'indiquer le lieu dit"
+
+
+* ^context.type = #element
+* ^context.expression = "Address.line"
+
+* value[x] only string

--- a/input/fsh/profiles-datatype/AsAddressExtendedProfile.fsh
+++ b/input/fsh/profiles-datatype/AsAddressExtendedProfile.fsh
@@ -28,7 +28,7 @@ Description: "Datatype profile créé à partir de FrAddress dans le contexte de
     iso21090-ADXP-streetNameType named streetNameType 0..1 and 
     iso21090-ADXP-postBox named postBox 0..1 and
     iso21090-ADXP-streetNameBase named streetNameBase 0..1 and
-	iso21090-ADXP-precinct named precinct 0..1 
+	as-ext-lieu-dit named lieuDit 0..1 
 
 	
 * line.extension[careOf] ^short = "pointRemise (Adresse)"
@@ -39,4 +39,4 @@ Description: "Datatype profile créé à partir de FrAddress dans le contexte de
 * line.extension[streetNameType].valueString from $JDV-J103-TypeVoie-RASS (required)
 * line.extension[postBox] ^short = "mentionDistribution (Adresse)"
 * line.extension[streetNameBase] ^short = "libelleVoie (Adresse)"
-* line.extension[precinct] ^short = "lieuDit (Adresse) : Lieu qui porte un nom rappelant une particularité topographique ou historique."
+* line.extension[lieuDit] ^short = "lieuDit (Adresse) : Lieu qui porte un nom rappelant une particularité topographique ou historique."


### PR DESCRIPTION
## Description des changements

* Suppression de precint pour créer une extension custom pour le lieu dit. En effet, [precinct](https://fr.wikipedia.org/wiki/Precinct) ne correspond pas à l'usage et est une expression typiquement américaine. De plus, cette extension va sur address et pas sur address.line

## Preview

https://ansforge.github.io/IG-fhir-annuaire/ig/nr-remplace-precint
https://ansforge.github.io/IG-fhir-annuaire/ig/nr-remplace-precint/StructureDefinition-as-address-extended.html

<img width="951" alt="image" src="https://github.com/ansforge/IG-fhir-annuaire/assets/48218773/28632905-8f1d-4cc5-b7c8-1527524156be">

