### PR TITLE
Changement de la version de dépendance du NOS à "latest"

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -12,7 +12,7 @@ publisher:
 dependencies:
   hl7.fhir.fr.core: 1.1.0
   hl7.fhir.extensions.r5: 4.0.1
-  ans.fr.nos: 1.1.0
+  ans.fr.nos: latest
 status: active
 version: 1.0.0-ballot-3
 fhirVersion: 4.0.1


### PR DESCRIPTION
## Description des changements

Je viens de retester et ça fonctionne maintenant @sdemeyANS @M-Priour.
La dernière fois que j'ai testé, ça n'était pris en charge par sushi uniquement, et pas par le publisher

[EDIT] A noter que ça prend la dernière version au moment de la publication et que ça la fixe à celle-ci.

## Preview

https://ansforge.github.io/IG-fhir-annuaire/ig/nr-change-nos-version-to-latest

