### PR TITLE
Ajout de champs manquants

### DIFF
--- a/input/fsh/profiles/AsHealthcareServiceSocialEquipmentProfile.fsh
+++ b/input/fsh/profiles/AsHealthcareServiceSocialEquipmentProfile.fsh
@@ -36,9 +36,21 @@ Description: "Profil générique créé à partir de HealthcareService dans le c
 * providedBy only Reference(fr-core-organization or AsOrganizationProfile)
 
 // disciplineEquipementSociale
-* type 0..* MS
-* type ^short = "La discipline déterminant la nature de l’activité (disciplineEquipementSociale)."
-* type from $JDV-J136-DisciplineEquipementSocial-RASS (required)
+* type MS
+
+* type ^slicing.discriminator.type = #pattern
+* type ^slicing.discriminator.path = "$this"
+* type ^slicing.rules = #open
+
+* type contains
+    category 0..1 and
+    activity 
+
+* type[category] ^short = "La catégorie de la discipline déterminant la nature de l’activité (disciplineEquipementSociale)."
+* type[category] from $JDV-J136-DisciplineEquipementSocial-RASS (required)
+
+* type[activity] ^short = "La discipline déterminant la nature de l’activité (CODE_ACT_SOIN)."
+* type[activity] from https://mos.esante.gouv.fr/NOS/JDV_J133-ActiviteSanitaireRegulee-RASS/FHIR/JDV-J133-ActiviteSanitaireRegulee-RASS (required)
 
 // clientele
 * eligibility 0..* MS


### PR DESCRIPTION
# Description des changements

## HealthcareService Activity

### DT_MAJ_SUR_ACT
DT_MAJ_SUR_ACT qui avait une extension dateUpdateActivity sur l'IG 0.1.0 avec l'url https://annuaire.sante.gouv.fr/fhir/StructureDefinition/HealthcareService-DateUpdateActivity et maintenant il est plus utilisé.
 

- [ ] est-ce que lastUpdated irait ?

### CODE_ACT_SOIN 

CODE_ACT_SOIN était sur le champ "type", mais maintenant il est plus utilisé et on utilise à sa place la valeur du champ TYPE_ACT_SOIN

- [ ] proposition dans HealthcareService.type[activity]

## HealthcareService Social Equipment
 
PREMIERE_INSTALL qui avait une extension installationDate sur l'IG 0.1.0 avec l'url https://annuaire.sante.gouv.fr/fhir/StructureDefinition/HealthcareService-DateUpdateActivity, Cela est peut être renseigné sur le champ dateLastInstallation de l'extension as-ext-healthcareservice-authorization?

- [ ] Est-ce que l'extension (qui était de type period) avait uniquement period.start utilisé ?



## Preview

https://ansforge.github.io/IG-fhir-annuaire/[ajouter_nom_de_la_branche]/ig
