### PR TITLE
Practitioner.identifier.type obligatoire & ADELI interdit

### DIFF
--- a/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
@@ -36,6 +36,8 @@ Description: 	"""Profil public applicatif créé à partir du profil générique
 // mailbox-mss - Donnees privees
 * telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[responsible] 0..0
 * telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[phone] 0..0
+// * telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[listeRouge] 0..0 // A vérifier
+
 // adresseCorrespondance
 * address 0..0
 

--- a/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
@@ -36,7 +36,6 @@ Description: 	"""Profil public applicatif créé à partir du profil générique
 // mailbox-mss - Donnees privees
 * telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[responsible] 0..0
 * telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[phone] 0..0
-// * telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[listeRouge] 0..0 // A vérifier
 
 // adresseCorrespondance
 * address 0..0

--- a/input/fsh/profiles/AsPractitionerProfile.fsh
+++ b/input/fsh/profiles/AsPractitionerProfile.fsh
@@ -26,6 +26,7 @@ Description: 	"Profil générique créé à partir de FrPractitioner dans le con
 * identifier.type ^short = "Type d’identifiant national de la personne physique (typeIdNat_PP),\r\nLes codes RPPS et IDNPS proviennent du system  https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203 ; Les codes 1, 3, 4, 5, 6 proviennent du system : https://mos.esante.gouv.fr/NOS/TRE_G08-TypeIdentifiantPersonne/FHIR/TRE-G08-TypeIdentifiantPersonne"
 
 * identifier[idNatPs] MS
+* identifier[idNatPs].type 1..1
 
 // // Identifiant interne à portée nationale. Celui-ci peut aussi être inclus dans l'idNatPs.
 // * identifier[identifiantInterne] ^short = "Identifiant interne à partée nationale du practicien. L'identifiant interne est composé d'un identifiant local propre à une structure et d'un identifiant national."

--- a/input/fsh/profiles/AsPractitionerProfile.fsh
+++ b/input/fsh/profiles/AsPractitionerProfile.fsh
@@ -26,13 +26,12 @@ Description: 	"Profil générique créé à partir de FrPractitioner dans le con
 * identifier.type ^short = "Type d’identifiant national de la personne physique (typeIdNat_PP),\r\nLes codes RPPS et IDNPS proviennent du system  https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203 ; Les codes 1, 3, 4, 5, 6 proviennent du system : https://mos.esante.gouv.fr/NOS/TRE_G08-TypeIdentifiantPersonne/FHIR/TRE-G08-TypeIdentifiantPersonne"
 
 * identifier[idNatPs] MS
-* identifier[idNatPs].type 1..1
+* identifier[idNatPs].type 1..1 // Contrainte ajoutée dans FrCore, ligne à supprimer à la prochaine release de FrCore 
 
 * identifier[rpps] MS
-* identifier[rpps].type 1..1
+* identifier[rpps].type 1..1 // Contrainte ajoutée dans FrCore, ligne à supprimer à la prochaine release de FrCore 
 
-* identifier[adeli] MS
-* identifier[adeli].type 1..1
+* identifier[adeli] 0..0 // Adeli décommissionné, ligne à supprimer au prochain héritage FrCore 
 
 // // Identifiant interne à portée nationale. Celui-ci peut aussi être inclus dans l'idNatPs.
 // * identifier[identifiantInterne] ^short = "Identifiant interne à partée nationale du practicien. L'identifiant interne est composé d'un identifiant local propre à une structure et d'un identifiant national."

--- a/input/fsh/profiles/AsPractitionerProfile.fsh
+++ b/input/fsh/profiles/AsPractitionerProfile.fsh
@@ -28,6 +28,12 @@ Description: 	"Profil générique créé à partir de FrPractitioner dans le con
 * identifier[idNatPs] MS
 * identifier[idNatPs].type 1..1
 
+* identifier[rpps] MS
+* identifier[rpps].type 1..1
+
+* identifier[adeli] MS
+* identifier[adeli].type 1..1
+
 // // Identifiant interne à portée nationale. Celui-ci peut aussi être inclus dans l'idNatPs.
 // * identifier[identifiantInterne] ^short = "Identifiant interne à partée nationale du practicien. L'identifiant interne est composé d'un identifiant local propre à une structure et d'un identifiant national."
 // * identifier[identifiantInterne].system 1..1


### PR DESCRIPTION
## Description des changements

* Practitioner.identifier.type rendu obligatoire
* le booléen listeRouge est commenté (info à ne pas publier)
* ...

## Preview

https://ansforge.github.io/IG-fhir-annuaire/nr-update/ig
