### PR TITLE
Suppression des identifiants internes des Organization et des Practitioner 

### DIFF
--- a/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh
@@ -13,15 +13,9 @@ Description: """Profil public applicatif créé à partir du profil générique 
 
 * identifier.period 0..0
 * identifier.assigner 0..0
-// Organization.identifier - slice identifiantInterne
 
-* identifier contains identifiantInterne 0..1 MS 
 
 // * identifier[idNatSt] 0..1 ^sliceName = "idNatSt"
-
-* identifier[identifiantInterne] ^short = "Identifiant interne à porté nationale des structures enregistrées au RPPS sans aucun identifiant métier.\nIl est composé de 14 chiffres.\nIl s’agit généralement de structures enregistrées temporairement par les ordres, en attente de vérification ou de changement d’identifiant."
-* identifier[identifiantInterne].type = https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203#INTRN
-* identifier[identifiantInterne].system = "http://rpps.interne.esante.gouv.fr"
 
 * active 1..1
 * contact 0..0

--- a/input/fsh/profiles/AsPractitionerProfile.fsh
+++ b/input/fsh/profiles/AsPractitionerProfile.fsh
@@ -33,12 +33,6 @@ Description: 	"Profil générique créé à partir de FrPractitioner dans le con
 
 * identifier[adeli] 0..0 // Adeli décommissionné, ligne à supprimer au prochain héritage FrCore 
 
-// // Identifiant interne à portée nationale. Celui-ci peut aussi être inclus dans l'idNatPs.
-// * identifier[identifiantInterne] ^short = "Identifiant interne à partée nationale du practicien. L'identifiant interne est composé d'un identifiant local propre à une structure et d'un identifiant national."
-// * identifier[identifiantInterne].system 1..1
-// * identifier[identifiantInterne].system from as-vs-intern-id-systems (required)
-// * identifier[identifiantInterne].system ^short = "Système de l'identifiant parmi les valeurs : finess.local.esante.gouv.fr | siren.local.esante.gouv.fr | siret.local.esante.gouv.fr | rpps.local.esante.gouv.fr "
-// * identifier[identifiantInterne].value ^short = "Valeur de l'identifiant au format xxxxx/yyyyy où xxxxx est l'identifiant finess/siren/siret/rpps et yyyyy l'identifiant local."
 
 // Practitioner.active
 * active MS
@@ -140,21 +134,6 @@ Description: 	"Profil générique créé à partir de FrPractitioner dans le con
 // Slice : savoirFaire
 * qualification[savoirFaire].code.coding[savoirFaire] MS
 
-// ValueSet: AsVSInterneIdSystems
-// Id: as-vs-intern-id-systems
-// Title: "Internal Id Systems VS"
-// Description: "Systèmes des identifiants internes"
-// * include codes from system https://interop.esante.gouv.fr/ig/fhir/annuaire/CodeSystem/as-cs-intern-id-systems
-
-
-// CodeSystem: AsCSInterneIdSystems
-// Id: as-cs-intern-id-systems
-// Title: "Internal Id Systems"
-// Description: "Systèmes des identifiants locaux"
-// * #finess.interne.esante.gouv.fr "Système de l'identifiant interne FINESS"
-// * #siren.interne.esante.gouv.fr "Système de l'identifiant interne SIREN"
-// * #siret.interne.esante.gouv.fr "Système de l'identifiant interne SIRET"
-// * #rpps.interne.esante.gouv.fr "Système de l'identifiant interne du cabinet RPPS"
 
 Mapping:  AsPractitionerProfileToMOSSavoirFaire
 Source:   AsPractitionerProfile


### PR DESCRIPTION
## Description des changements

* Les identifiants internes des Practitioner ont déjà été supprimés https://github.com/ansforge/IG-fhir-annuaire/pull/259

## Preview

https://build.fhir.org/ig/ansforge/IG-fhir-annuaire/branches/[ajouter_nom_de_la_branche]

https://ansforge.github.io/IG-fhir-annuaire/[nom_de_la_branche]/ig/
