### PR TITLE
feat: ajout du paramètre de recherche sur le type de BAL MSSanté

### DIFF
--- a/input/fsh/SearchParameters/AsMailboxMssTypeSearchParameter.fsh
+++ b/input/fsh/SearchParameters/AsMailboxMssTypeSearchParameter.fsh
@@ -1,0 +1,12 @@
+Instance: as-sp-mailbox-mss-type
+InstanceOf: SearchParameter
+Usage: #definition
+* status = #active
+* name = "AsMailboxMssTypeSearchParameter"
+* description = "Paramètre de recherche pour récupérer une organisation, un praticien ou une situation d'exercice par type de BAL MSSanté."
+* code = #mailbox-mss-type
+* base[0] = #Organization
+* base[+] = #Practitioner
+* base[+] = #PractitionerRole
+* type = #token
+* expression = "telecom.extension.where(url='https://interop.esante.gouv.fr/ig/fhir/annuaire/StructureDefinition/as-ext-mailbox-mss-metadata').extension.where(url='type').value"


### PR DESCRIPTION
## Description des changements

* Ajout du paramètre de recherche `mailbox-mss-type` permettant de filtrer par type de BAL MSSanté (`metadata.type`, valeurs : ORG, APP, PER, CAB)

## Preview

https://build.fhir.org/ig/ansforge/IG-fhir-annuaire/branches/nr-add-sp-bal-type

https://ansforge.github.io/IG-fhir-annuaire/nr-add-sp-bal-type/ig/