### PR TITLE
Tag MS sur les slices plutôt que sur l'attribut général pour le profil DP du PractitionerRole

### DIFF
--- a/input/fsh/profiles-dp/AsDpDeviceProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpDeviceProfile.fsh
@@ -12,7 +12,6 @@ Description: """Profil public applicatif créé à partir du profil générique 
 * meta.profile[as-dp-canonical] = Canonical(as-dp-device)
 
 * extension[as-ext-authorization] MS
-* identifier MS
 * status MS
 * type MS
 * owner MS
@@ -22,7 +21,7 @@ Description: """Profil public applicatif créé à partir du profil générique 
 * insert rs-as-core
 * meta.extension[as-ext-data-trace] MS
 
-* identifier[numAutorisationArhgos] 1..1
+* identifier[numAutorisationArhgos] 1..1 MS
 
 * status 1..1
 * definition 0..0

--- a/input/fsh/profiles-dp/AsDpHealthcareServiceSocialEquipmentProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpHealthcareServiceSocialEquipmentProfile.fsh
@@ -15,7 +15,6 @@ Description: """Profil public applicatif créé à partir du profil générique 
 * extension[as-ext-installation] MS
 * extension[as-ext-patient-type] MS
 * extension[as-ext-supported-capacity] MS
-* identifier MS
 * type MS
 * eligibility MS
 * characteristic MS

--- a/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh
@@ -15,13 +15,18 @@ Description: """Profil public applicatif créé à partir du profil générique 
 * extension[as-ext-organization-budget-type] MS
 * extension[as-ext-organization-authorization-deadline] MS
 
-* identifier[idNatSt] MS 
+* identifier[idNatSt] MS
+* identifier[rppsRang] MS
+* identifier[finess] MS
+* identifier[siren] MS
+* identifier[siret] MS
+* identifier[adeliRang] MS
 * active MS
 * name MS
 * alias MS
 * type MS
 * address MS
-* telecom MS
+* telecom[mailbox-mss] MS
 * endpoint MS
 
 

--- a/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
@@ -37,6 +37,7 @@ Description: 	"""Profil public applicatif créé à partir du profil générique
 
 // telecommunication - boiteLettreMSS
 * telecom ^slicing.rules = #closed // only boiteLettreMSS is an open data
+* telecom[mailbox-mss] MS
 
 // mailbox-mss - Donnees privees
 * telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[responsible] 0..0

--- a/input/fsh/profiles-dp/AsDpPractitionerRoleProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpPractitionerRoleProfile.fsh
@@ -25,7 +25,7 @@ Description: 	"""Profil public applicatif créé à partir du profil générique
 * code[statutHospitalier] MS
 * code[fonction] MS
 * code[metierPharmacien] MS
-* telecom MS
+* telecom[mailbox-mss] MS
 * availableTime MS
 * notAvailable MS
 * availabilityExceptions MS

--- a/input/fsh/profiles-dp/AsDpPractitionerRoleProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpPractitionerRoleProfile.fsh
@@ -15,7 +15,6 @@ Description: 	"""Profil public applicatif créé à partir du profil générique
 * practitioner MS 
 * organization MS
 * healthcareService MS
-* identifier MS
 * active MS
 * period MS
 * code[genreActivite] MS


### PR DESCRIPTION
## Description des changements

* [input/fsh/profiles-dp/AsDpPractitionerRoleProfile.fsh](https://github.com/ansforge/IG-fhir-annuaire/blob/nr-update-ms-slices/input/fsh/profiles-dp/AsDpPractitionerRoleProfile.fsh) : Suppression de `* identifier MS` sur le champ générique ; ajout de `* telecom[mailbox-mss] MS` sur la slice utilisée
* [input/fsh/profiles-dp/AsDpPractitionerProfile.fsh](https://github.com/ansforge/IG-fhir-annuaire/blob/nr-update-ms-slices/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh) : Ajout de `* telecom[mailbox-mss] MS` sur la slice utilisée
* [input/fsh/profiles-dp/AsDpOrganizationProfile.fsh](https://github.com/ansforge/IG-fhir-annuaire/blob/nr-update-ms-slices/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh) : Suppression de `* telecom MS` sur le champ générique ; ajout de MS sur les slices identifier utilisées (`rppsRang`, `finess`, `siren`, `siret`, `adeliRang`) et sur `telecom[mailbox-mss]`
* [input/fsh/profiles-dp/AsDpDeviceProfile.fsh](https://github.com/ansforge/IG-fhir-annuaire/blob/nr-update-ms-slices/input/fsh/profiles-dp/AsDpDeviceProfile.fsh) : Suppression de `* identifier MS` sur le champ générique ; ajout de MS sur `identifier[numAutorisationArhgos]`
* [input/fsh/profiles-dp/AsDpHealthcareServiceSocialEquipmentProfile.fsh](https://github.com/ansforge/IG-fhir-annuaire/blob/nr-update-ms-slices/input/fsh/profiles-dp/AsDpHealthcareServiceSocialEquipmentProfile.fsh) : Suppression de `* identifier MS` sur le champ générique (cohérent avec `* identifier ..0`)

## Preview

https://build.fhir.org/ig/ansforge/IG-fhir-annuaire/branches/nr-update-ms-slices

https://ansforge.github.io/IG-fhir-annuaire/nr-update-ms-slices/ig/