### PR TITLE
fix: tag MS sur les slices plutôt que sur l'attribut de base (profils DP)

### DIFF
--- a/input/fsh/profiles-dp/AsDpHealthcareServiceSocialEquipmentProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpHealthcareServiceSocialEquipmentProfile.fsh
@@ -15,7 +15,7 @@ Description: """Profil public applicatif créé à partir du profil générique 
 * extension[as-ext-installation] MS
 * extension[as-ext-patient-type] MS
 * extension[as-ext-supported-capacity] MS
-* type MS
+* type[category] MS
 * eligibility MS
 * characteristic MS
 

--- a/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh
@@ -24,7 +24,12 @@ Description: """Profil public applicatif créé à partir du profil générique 
 * active MS
 * name MS
 * alias MS
-* type MS
+* type[organizationType] MS
+* type[secteurActiviteRASS] MS
+* type[categorieEtablissementRASS] MS
+* type[statutJuridiqueINSEE] MS
+* type[sphParticipation] MS
+* type[typeEtablissement] MS
 * address MS
 * telecom[mailbox-mss] MS
 * endpoint MS

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -20,7 +20,7 @@ fhirVersion: 4.0.1
 copyrightYear: 2020+
 # releaseLabel: final-text
 releaseLabel: ci-build
-jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
+jurisdiction: urn:iso:std:iso:3166#FR "France (la)"
 
 parameters:
     shownav: 'true'


### PR DESCRIPTION
## Description des changements

* [AsDpOrganizationProfile.fsh] Remplacement de `* type MS` (attribut de base) par les règles MS sur chaque slice : `organizationType`, `secteurActiviteRASS`, `categorieEtablissementRASS`, `statutJuridiqueINSEE`, `sphParticipation`, `typeEtablissement`
* [AsDpHealthcareServiceSocialEquipmentProfile.fsh] Remplacement de `* type MS` (attribut de base) par `* type[category] MS` (slice)
* [sushi-config.yaml] Correction de la valeur de `jurisdiction` (`"FRANCE"` → `"France (la)"`)

Ces corrections résolvent les warnings QA du type : _"The slice 'X' on path 'Y' is not marked as 'must-support' which is not consistent with the element that defines the slicing, where 'must-support' is true"_

## Preview

https://build.fhir.org/ig/ansforge/IG-fhir-annuaire/branches/nr-update-ms-slice-2

https://ansforge.github.io/IG-fhir-annuaire/nr-update-ms-slice-2/ig/