### PR TITLE
feat(balmss): suppression des champs dématérialisation et phone

### DIFF
--- a/input/fsh/examples/AsOrganizationExampleNancy.fsh
+++ b/input/fsh/examples/AsOrganizationExampleNancy.fsh
@@ -47,8 +47,6 @@ InstanceOf: AsOrganizationProfile
 * telecom[3].extension[=].extension[=].valueCodeableConcept = https://mos.esante.gouv.fr/NOS/TRE_R257-TypeBAL/FHIR/TRE-R257-TypeBAL#ORG
 * telecom[3].extension[=].extension[+].url = "description"
 * telecom[3].extension[=].extension[=].valueString = "Description-mss"
-* telecom[3].extension[=].extension[+].url = "digitization"
-* telecom[3].extension[=].extension[=].valueBoolean = true
 * telecom[3].extension[=].extension[+].url = "listeRouge"
 * telecom[3].extension[=].extension[=].valueBoolean = false
 * telecom[3].system = #email

--- a/input/fsh/extensions/ASMailboxMetadataExtension.fsh
+++ b/input/fsh/extensions/ASMailboxMetadataExtension.fsh
@@ -15,7 +15,6 @@ Description: 	"Extension contenant les métadonnées de la mailbox mss."
     description 0..1 and
     responsible 0..1 and
     service 0..1 and
-    phone 0..1 and
     listeRouge 0..1
 
 // typeBAL
@@ -34,10 +33,6 @@ Description: 	"Extension contenant les métadonnées de la mailbox mss."
 // serviceRattachement
 * extension[service].value[x] only string
 * extension[service] ^short = "serviceRattachement : Nom et description du service de rattachement de l’utilisateur de la boîte aux lettres dans l’organisation."
-
-// telephone
-* extension[phone].value[x] only string
-* extension[phone] ^short = "telephone : Coordonnées téléphoniques spécifiques à l’usage de la boîte aux lettres MSSanté."
 
 // listeRouge
 * extension[listeRouge].value[x] only boolean

--- a/input/fsh/extensions/ASMailboxMetadataExtension.fsh
+++ b/input/fsh/extensions/ASMailboxMetadataExtension.fsh
@@ -16,7 +16,6 @@ Description: 	"Extension contenant les métadonnées de la mailbox mss."
     responsible 0..1 and
     service 0..1 and
     phone 0..1 and
-    digitization 0..1 and
     listeRouge 0..1
 
 // typeBAL
@@ -39,10 +38,6 @@ Description: 	"Extension contenant les métadonnées de la mailbox mss."
 // telephone
 * extension[phone].value[x] only string
 * extension[phone] ^short = "telephone : Coordonnées téléphoniques spécifiques à l’usage de la boîte aux lettres MSSanté."
-
-// dematerialisation
-* extension[digitization].value[x] only boolean
-* extension[digitization] ^short = "dematerialisation : Indicateur d’acceptation de la dématérialisation (ou « Zéro papier »). - \"true\" : Dématérialisation acceptée \r\n- \"false\" : Dématérialisation refusée."
 
 // listeRouge
 * extension[listeRouge].value[x] only boolean

--- a/input/fsh/profiles-datatype/AsMailboxMSSProfile.fsh
+++ b/input/fsh/profiles-datatype/AsMailboxMSSProfile.fsh
@@ -18,7 +18,7 @@ Description: 	"Datatype profile créé à partir ContactPoint dans le cadre de l
 * extension[emailType].valueCoding = https://mos.esante.gouv.fr/NOS/TRE_R256-TypeMessagerie/FHIR/TRE-R256-TypeMessagerie#MSSANTE
 
 * extension contains as-ext-mailbox-mss-metadata named as-mailbox-mss-metadata 0..1
-* extension[as-mailbox-mss-metadata] ^short = "Les attributs 'responsible' et 'phone' ne sont pas disponibles en accès libre."
+* extension[as-mailbox-mss-metadata] ^short = "L'attribut 'responsible' n'est pas disponible en accès libre."
 
 
 Mapping:  AsMailboxMSSProfileToMOSBoiteLettreMSS

--- a/input/fsh/profiles-datatype/AsMailboxMSSProfile.fsh
+++ b/input/fsh/profiles-datatype/AsMailboxMSSProfile.fsh
@@ -30,7 +30,6 @@ Title:    "AsMailboxMSSProfile to MOS - boiteLettresMSS"
 * extension[emailType] -> "boiteLettresMSS.typeBAL"
 * extension[as-mailbox-mss-metadata].extension[description] -> "boiteLettresMSS.description"
 * extension[as-mailbox-mss-metadata].extension[service] -> "BoiteLettreMSS.serviceRattachement"
-* extension[as-mailbox-mss-metadata].extension[digitization] -> "BoiteLettreMSS.dematerialisation"
 * extension[as-mailbox-mss-metadata].extension[listeRouge] -> "BoiteLettreMSS.listeRouge"
 
 

--- a/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh
@@ -52,5 +52,4 @@ Description: """Profil public applicatif créé à partir du profil générique 
 * endpoint 0..0
 // mailbox-mss - Donnees privees
 * telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[responsible] 0..0
-* telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[phone] 0..0
 * telecom.period 0..0 // telecom is used to show mail, fax, or org phone. History is only available for DR 

--- a/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
@@ -41,7 +41,6 @@ Description: 	"""Profil public applicatif créé à partir du profil générique
 
 // mailbox-mss - Donnees privees
 * telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[responsible] 0..0
-* telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[phone] 0..0
 * telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[listeRouge] 0..0
 
 * gender 0..0

--- a/input/fsh/profiles-dp/AsDpPractitionerRoleProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpPractitionerRoleProfile.fsh
@@ -45,7 +45,6 @@ Description: 	"""Profil public applicatif créé à partir du profil générique
 * telecom ^slicing.rules = #closed // only boiteLettreMSS is an open data
 // mailbox-mss - Donnees privees
 * telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[responsible] 0..0
-* telecom[mailbox-mss].extension[as-mailbox-mss-metadata].extension[phone] 0..0
 * availableTime 0..0
 * notAvailable 0..0
 * availabilityExceptions 0..0


### PR DESCRIPTION
## Description des changements

* `ASMailboxMetadataExtension.fsh` — suppression du slice `digitization` dans l'extension `as-ext-mailbox-mss-metadata`
* `AsMailboxMSSProfile.fsh` — suppression du mapping `digitization → BoiteLettreMSS.dematerialisation`
* `AsOrganizationExampleNancy.fsh` — suppression de l'attribut `digitization` dans l'exemple

## Preview

https://ansforge.github.io/IG-fhir-annuaire/nr-remove-digitization/ig