### PR TITLE
chore: mise à jour du change-log pour la release 1.2.0

### DIFF
--- a/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
@@ -8,10 +8,17 @@ Description: 	"""Profil public applicatif créé à partir du profil générique
 * meta.profile[as-dp-canonical] = Canonical(as-dp-practitioner)
 * meta.profile[fr-canonical] 1..1
 
-* extension[as-ext-registration] MS
-* extension[as-ext-frpractitioner-authorization] MS
+// extensions
+* extension[as-ext-registration] 0..0 // inscription à l'ordre
+
+* extension[as-ext-frpractitioner-authorization] MS 
+//AutorisationExercice : Il s'agit d'une autorisation délivrée par le Ministère de la Santé ou par l'Ordre au professionnel pour accès à l'exercice de la profession.
+
+* extension[as-ext-digital-certificate] 0..0
+
 * extension[as-ext-smartcard] MS
-* extension[as-ext-digital-certificate] MS
+* extension[as-ext-smartcard].extension[oppositionDate] 0..0
+
 * identifier[idNatPs] MS
 * identifier[rpps] MS
 
@@ -59,11 +66,5 @@ Description: 	"""Profil public applicatif créé à partir du profil générique
 // langueParlee
 * communication 0..0
 
-// extensions
-* extension[as-ext-registration] 0..0
-* extension[as-ext-frpractitioner-authorization] 0..0
-* extension[as-ext-digital-certificate] 0..0
 
-
-* extension[as-ext-smartcard].extension[oppositionDate] 0..0
 

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -1,3 +1,27 @@
+### Release 1.2.0 de l'Implementation Guide Annuaire
+
+Modifications apportées dans la [1.2.0](https://github.com/ansforge/IG-fhir-annuaire/pulls?q=is%3Apr+is%3Aclosed+milestone%3A1.2.0) :
+
+* Mise à jour vers le nouveau template HL7 [302](https://github.com/ansforge/IG-fhir-annuaire/pull/302)
+* Suppression des champs dématérialisation et phone de l'API BAL MSSanté [301](https://github.com/ansforge/IG-fhir-annuaire/pull/301)
+* Tag MS sur les slices plutôt que sur l'attribut de base (profils DP) [300](https://github.com/ansforge/IG-fhir-annuaire/pull/300)
+* Tag MS sur les slices plutôt que sur l'attribut général pour le profil DP du PractitionerRole [299](https://github.com/ansforge/IG-fhir-annuaire/pull/299)
+* Ajout du paramètre de recherche sur le type de BAL MSSanté [296](https://github.com/ansforge/IG-fhir-annuaire/pull/296)
+* Obsolescence et remplacement des JDV MOS NOS [294](https://github.com/ansforge/IG-fhir-annuaire/pull/294)
+* Ajout identifier type short au profil AsOrganization [290](https://github.com/ansforge/IG-fhir-annuaire/pull/290)
+* Ajout du meta.source aux profils applicatifs [286](https://github.com/ansforge/IG-fhir-annuaire/pull/286)
+* Ajout de données manquantes pour l'API Données Restreintes [285](https://github.com/ansforge/IG-fhir-annuaire/pull/285)
+* Ajout du paramètre de recherche pour chercher par organization period [284](https://github.com/ansforge/IG-fhir-annuaire/pull/284)
+* Suppression du numéro assurance maladie [283](https://github.com/ansforge/IG-fhir-annuaire/pull/283)
+* Déplacement des tags MS (Must Support) [282](https://github.com/ansforge/IG-fhir-annuaire/pull/282)
+* Suppression du profil Location [281](https://github.com/ansforge/IG-fhir-annuaire/pull/281)
+* Ajout de la page problématiques connues [280](https://github.com/ansforge/IG-fhir-annuaire/pull/280)
+* Suppression des identifiants internes des Organization et des Practitioner [278](https://github.com/ansforge/IG-fhir-annuaire/pull/278)
+* Mise à jour des descriptions des profils génériques [276](https://github.com/ansforge/IG-fhir-annuaire/pull/276)
+* Mise en conformité avec le nouvel arrêté RPPS [271](https://github.com/ansforge/IG-fhir-annuaire/pull/271)
+* Mise à jour du CapabilityStatement avec URLs canoniques et modifiers [269](https://github.com/ansforge/IG-fhir-annuaire/pull/269)
+* Création du CapabilityStatement pour l'API v2 [268](https://github.com/ansforge/IG-fhir-annuaire/pull/268)
+
 ### Release 1.1.0 de l'Implementation Guide Annuaire
 
 Modifications apportées dans la release [1.1.0](https://github.com/ansforge/IG-fhir-annuaire/pulls?q=is%3Apr+is%3Aclosed+milestone%3A1.1.0) :

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,12 +1,15 @@
 {
     "package-id" : "ans.fhir.fr.annuaire",
-    "version" : "1.1.0",
-    "path" : "https://interop.esante.gouv.fr/ig/fhir/annuaire/1.1.0",
-    "mode" : "milestone",
-    "status" : "release",
-    "sequence" : "final-text",
-    "desc" : "Guide d'implémentation 1.1.0 de l'API annuaire santé",
-    "descmd": "Guide d'implémentation 1.1.0-snapshot-6 de l'API annuaire santé",
+    "version" : "1.2.0-snapshot-1",
+    "path" : "https://interop.esante.gouv.fr/ig/fhir/annuaire/1.2.0-snapshot-1",
+    "mode" : "working",
+    "status" : "draft",
+    "sequence" : "Snapshot",
+    "desc" : "Guide d'implémentation 1.2.0-snapshot-1 de l'API annuaire santé",
+    "descmd": "Guide d'implémentation 1.2.0-snapshot-1 de l'API annuaire santé",
     "changes": "changes.html",
-    "ci-build" : "https://build.fhir.org/ig/ansforge/IG-fhir-annuaire/"
+    "ci-build" : "https://build.fhir.org/ig/ansforge/IG-fhir-annuaire/",
+    "registry-description" : "Ressources de conformité basées sur le modèle d'exposition de l'Annuaire Santé.",
+    "registry-country" : "fr",
+    "registry-authority" : "ANS (FR)"
 }

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -14,12 +14,12 @@ dependencies:
   hl7.fhir.uv.xver-r5.r4: latest
   ans.fr.nos: latest
   hl7.terminology.r4: 5.5.0
-status: active
-version: 1.1.0
+status: draft
+version: 1.2.0-snapshot-1
 fhirVersion: 4.0.1
 copyrightYear: 2020+
 # releaseLabel: final-text
-releaseLabel: ci-build
+releaseLabel: snapshot
 jurisdiction: urn:iso:std:iso:3166#FR "France (la)"
 
 parameters: #Parameters list - https://build.fhir.org/ig/FHIR/fhir-tools-ig/CodeSystem-ig-parameters.html

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -12,7 +12,7 @@ publisher:
 dependencies:
   hl7.fhir.fr.core: 2.1.0
   hl7.fhir.uv.xver-r5.r4: latest
-  ans.fr.nos: latest
+  ans.fr.terminologies: latest
   hl7.terminology.r4: 5.5.0
 status: draft
 version: 1.2.0-snapshot-1


### PR DESCRIPTION
## Description des changements

* `sushi-config.yaml` : version `1.1.0` → `1.2.0-snapshot-1`, status `active` → `draft`, releaseLabel `ci-build` → `snapshot`
* `publication-request.json` : version, path, mode (`milestone` → `working`), status (`release` → `draft`), sequence (`final-text` → `Snapshot`), ajout des champs registry
* `input/pagecontent/changes.md` : ajout de la section 1.2.0 listant les 19 PRs mergées depuis la 1.1.0 (#268 à #302)

## Preview

https://build.fhir.org/ig/ansforge/IG-fhir-annuaire/branches/nr-prepare-snap-release

https://ansforge.github.io/IG-fhir-annuaire/nr-prepare-snap-release/ig/