### PR TITLE
Mise à jour de l'héritage FRCore vers 2.2.0

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -47,6 +47,7 @@ Alias: $JDV-J83-AutoriteEnregistrement-RASS = https://mos.esante.gouv.fr/NOS/JDV
 Alias: $JDV-J85-StatutInscription-RASS = https://mos.esante.gouv.fr/NOS/JDV_J85-StatutInscription-RASS/FHIR/JDV-J85-StatutInscription-RASS
 Alias: $JDV-J128-TypeCarte-RASS = https://mos.esante.gouv.fr/NOS/JDV_J128-TypeCarte-RASS/FHIR/JDV-J128-TypeCarte-RASS
 Alias: $JDV-J101-SecteurActivite-RASS = https://mos.esante.gouv.fr/NOS/JDV_J101-SecteurActivite-RASS/FHIR/JDV-J101-SecteurActivite-RASS
+Alias: $JDV-J129-CategorieEtablissement-RASS = https://mos.esante.gouv.fr/NOS/JDV_J129-CategorieEtablissement-RASS/FHIR/JDV-J129-CategorieEtablissement-RASS
 Alias: $JDV-J380-CategorieEntiteGeographiqueExercice-RASS = https://smt.esante.gouv.fr/fhir/ValueSet/jdv-j380-categorie-entite-geographique-exercice-rass
 Alias: $JDV-J78-Civilite-RASS = https://mos.esante.gouv.fr/NOS/JDV_J78-Civilite-RASS/FHIR/JDV-J78-Civilite-RASS
 Alias: $JDV-J79-CiviliteExercice-RASS = https://mos.esante.gouv.fr/NOS/JDV_J79-CiviliteExercice-RASS/FHIR/JDV-J79-CiviliteExercice-RASS

--- a/input/fsh/examples/DP/PP16DP-Organization.fsh
+++ b/input/fsh/examples/DP/PP16DP-Organization.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-02T01:00:00.000+01:00"
-  * profile[as-dp-canonical] = Canonical(as-dp-organization)
+  * profile[as-dp-canonical] = Canonical(as-dp-organization|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-organization|2.2.0"
 // Actif
 * active = true

--- a/input/fsh/examples/DP/PP16DP-Organization.fsh
+++ b/input/fsh/examples/DP/PP16DP-Organization.fsh
@@ -12,7 +12,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-02T01:00:00.000+01:00"
   * profile[as-dp-canonical] = Canonical(as-dp-organization)
-  * profile[fr-canonical] = Canonical(fr-core-organization)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-organization|2.2.0"
 // Actif
 * active = true
 

--- a/input/fsh/examples/DP/PP16DP-Organization.fsh
+++ b/input/fsh/examples/DP/PP16DP-Organization.fsh
@@ -11,6 +11,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-02T01:00:00.000+01:00"
+  * profile[as-dp-canonical] = Canonical(as-dp-organization)
+  * profile[fr-canonical] = Canonical(fr-core-organization)
 // Actif
 * active = true
 

--- a/input/fsh/examples/DP/PP16DP-Organization.fsh
+++ b/input/fsh/examples/DP/PP16DP-Organization.fsh
@@ -38,7 +38,7 @@ Usage: #example
   * type
     * coding[+]
       * system = "https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203"
-      * code = #INTRN
+      * code = #RPPSRG
 
 // Nom
 * name = "PHARMACIE NOLOT"

--- a/input/fsh/examples/DP/PP16DP-Practitioner.fsh
+++ b/input/fsh/examples/DP/PP16DP-Practitioner.fsh
@@ -11,6 +11,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-08-31T01:00:00.000+01:00"
+  * profile[as-dp-canonical] = Canonical(as-dp-practitioner)
+  * profile[fr-canonical] = Canonical(fr-core-practitioner)
 
 // Actif
 * active = true

--- a/input/fsh/examples/DP/PP16DP-Practitioner.fsh
+++ b/input/fsh/examples/DP/PP16DP-Practitioner.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-08-31T01:00:00.000+01:00"
-  * profile[as-dp-canonical] = Canonical(as-dp-practitioner)
+  * profile[as-dp-canonical] = Canonical(as-dp-practitioner|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DP/PP16DP-Practitioner.fsh
+++ b/input/fsh/examples/DP/PP16DP-Practitioner.fsh
@@ -12,7 +12,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-08-31T01:00:00.000+01:00"
   * profile[as-dp-canonical] = Canonical(as-dp-practitioner)
-  * profile[fr-canonical] = Canonical(fr-core-practitioner)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DP/PP16DP-PractitionerRole.fsh
+++ b/input/fsh/examples/DP/PP16DP-PractitionerRole.fsh
@@ -13,13 +13,15 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-08-31T01:00:00.000+01:00"
+  * profile[as-dp-canonical] = Canonical(as-dp-practitionerrole)
+  * profile[fr-canonical] = Canonical(fr-core-practitioner-role)
 
 // Actif
 * active = true
 
 // Identifiant fonctionnel 
-* identifier[+]
-  * system = "https://annuaire.sante.fr"
+* identifier[idSituationExercice]
+  * system = "https://rpps.esante.gouv.fr"
   * value = "1001500032"
 
 // Lien professionnel 

--- a/input/fsh/examples/DP/PP16DP-PractitionerRole.fsh
+++ b/input/fsh/examples/DP/PP16DP-PractitionerRole.fsh
@@ -14,7 +14,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-08-31T01:00:00.000+01:00"
   * profile[as-dp-canonical] = Canonical(as-dp-practitionerrole)
-  * profile[fr-canonical] = Canonical(fr-core-practitioner-role)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner-role|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DP/PP16DP-PractitionerRole.fsh
+++ b/input/fsh/examples/DP/PP16DP-PractitionerRole.fsh
@@ -13,7 +13,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-08-31T01:00:00.000+01:00"
-  * profile[as-dp-canonical] = Canonical(as-dp-practitionerrole)
+  * profile[as-dp-canonical] = Canonical(as-dp-practitionerrole|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner-role|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DP/PP19DP-Organization-EG-CH.fsh
+++ b/input/fsh/examples/DP/PP19DP-Organization-EG-CH.fsh
@@ -11,6 +11,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-01T01:00:00.000+01:00"
+  * profile[as-dp-canonical] = Canonical(as-dp-organization)
+  * profile[fr-canonical] = Canonical(fr-core-organization)
 
 // Actif
 * active = true

--- a/input/fsh/examples/DP/PP19DP-Organization-EG-CH.fsh
+++ b/input/fsh/examples/DP/PP19DP-Organization-EG-CH.fsh
@@ -12,7 +12,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-01T01:00:00.000+01:00"
   * profile[as-dp-canonical] = Canonical(as-dp-organization)
-  * profile[fr-canonical] = Canonical(fr-core-organization)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-organization|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DP/PP19DP-Organization-EG-CH.fsh
+++ b/input/fsh/examples/DP/PP19DP-Organization-EG-CH.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-01T01:00:00.000+01:00"
-  * profile[as-dp-canonical] = Canonical(as-dp-organization)
+  * profile[as-dp-canonical] = Canonical(as-dp-organization|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-organization|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DP/PP19DP-Organization-EG-CH.fsh
+++ b/input/fsh/examples/DP/PP19DP-Organization-EG-CH.fsh
@@ -39,7 +39,7 @@ Usage: #example
   * type
     * coding[+]
       * system = "https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203"
-      * code = #INTRN
+      * code = #RPPSRG
 
 // Nom
 * name = "CH EURE-SEINE"

--- a/input/fsh/examples/DP/PP19DP-Organization-EJ-Cab.fsh
+++ b/input/fsh/examples/DP/PP19DP-Organization-EJ-Cab.fsh
@@ -11,6 +11,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-01T01:00:00.000+01:00"
+  * profile[as-dp-canonical] = Canonical(as-dp-organization)
+  * profile[fr-canonical] = Canonical(fr-core-organization)
 
 // Actif
 * active = true

--- a/input/fsh/examples/DP/PP19DP-Organization-EJ-Cab.fsh
+++ b/input/fsh/examples/DP/PP19DP-Organization-EJ-Cab.fsh
@@ -12,7 +12,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-01T01:00:00.000+01:00"
   * profile[as-dp-canonical] = Canonical(as-dp-organization)
-  * profile[fr-canonical] = Canonical(fr-core-organization)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-organization|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DP/PP19DP-Organization-EJ-Cab.fsh
+++ b/input/fsh/examples/DP/PP19DP-Organization-EJ-Cab.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-01T01:00:00.000+01:00"
-  * profile[as-dp-canonical] = Canonical(as-dp-organization)
+  * profile[as-dp-canonical] = Canonical(as-dp-organization|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-organization|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DP/PP19DP-Organization-EJ-Cab.fsh
+++ b/input/fsh/examples/DP/PP19DP-Organization-EJ-Cab.fsh
@@ -31,7 +31,7 @@ Usage: #example
   * type
     * coding[+]
       * system = "https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203"
-      * code = #INTRN
+      * code = #RPPSRG
 
 // Nom
 * name = "CABINET SAINT ANTOINE"

--- a/input/fsh/examples/DP/PP19DP-Practitioner.fsh
+++ b/input/fsh/examples/DP/PP19DP-Practitioner.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
-  * profile[as-dp-canonical] = Canonical(as-dp-practitioner)
+  * profile[as-dp-canonical] = Canonical(as-dp-practitioner|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DP/PP19DP-Practitioner.fsh
+++ b/input/fsh/examples/DP/PP19DP-Practitioner.fsh
@@ -11,6 +11,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
+  * profile[as-dp-canonical] = Canonical(as-dp-practitioner)
+  * profile[fr-canonical] = Canonical(fr-core-practitioner)
 
 // Actif
 * active = true

--- a/input/fsh/examples/DP/PP19DP-Practitioner.fsh
+++ b/input/fsh/examples/DP/PP19DP-Practitioner.fsh
@@ -12,7 +12,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
   * profile[as-dp-canonical] = Canonical(as-dp-practitioner)
-  * profile[fr-canonical] = Canonical(fr-core-practitioner)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DP/PP19DP-PractitionerRole-Lib.fsh
+++ b/input/fsh/examples/DP/PP19DP-PractitionerRole-Lib.fsh
@@ -14,7 +14,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
   * profile[as-dp-canonical] = Canonical(as-dp-practitionerrole)
-  * profile[fr-canonical] = Canonical(fr-core-practitioner-role)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner-role|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DP/PP19DP-PractitionerRole-Lib.fsh
+++ b/input/fsh/examples/DP/PP19DP-PractitionerRole-Lib.fsh
@@ -13,13 +13,15 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
+  * profile[as-dp-canonical] = Canonical(as-dp-practitionerrole)
+  * profile[fr-canonical] = Canonical(fr-core-practitioner-role)
 
 // Actif
 * active = true
 
 // Identifiant fonctionnel 
-* identifier[+]
-  * system = "https://annuaire.sante.fr"
+* identifier[idSituationExercice]
+  * system = "https://rpps.esante.gouv.fr"
   * value = "1010399870"
 
 // Lien professionnel

--- a/input/fsh/examples/DP/PP19DP-PractitionerRole-Lib.fsh
+++ b/input/fsh/examples/DP/PP19DP-PractitionerRole-Lib.fsh
@@ -13,7 +13,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
-  * profile[as-dp-canonical] = Canonical(as-dp-practitionerrole)
+  * profile[as-dp-canonical] = Canonical(as-dp-practitionerrole|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner-role|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DP/PP19DP-PractitionerRole-Sal.fsh
+++ b/input/fsh/examples/DP/PP19DP-PractitionerRole-Sal.fsh
@@ -14,7 +14,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
   * profile[as-dp-canonical] = Canonical(as-dp-practitionerrole)
-  * profile[fr-canonical] = Canonical(fr-core-practitioner-role)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner-role|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DP/PP19DP-PractitionerRole-Sal.fsh
+++ b/input/fsh/examples/DP/PP19DP-PractitionerRole-Sal.fsh
@@ -13,13 +13,15 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
+  * profile[as-dp-canonical] = Canonical(as-dp-practitionerrole)
+  * profile[fr-canonical] = Canonical(fr-core-practitioner-role)
 
 // Actif
 * active = true
 
 // Identifiant fonctionnel 
-* identifier[+]
-  * system = "https://annuaire.sante.fr"
+* identifier[idSituationExercice]
+  * system = "https://rpps.esante.gouv.fr"
   * value = "F58000880311022013"
 
 // Lien professionnel

--- a/input/fsh/examples/DP/PP19DP-PractitionerRole-Sal.fsh
+++ b/input/fsh/examples/DP/PP19DP-PractitionerRole-Sal.fsh
@@ -13,7 +13,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
-  * profile[as-dp-canonical] = Canonical(as-dp-practitionerrole)
+  * profile[as-dp-canonical] = Canonical(as-dp-practitionerrole|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner-role|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DR/PP16DR-Organization.fsh
+++ b/input/fsh/examples/DR/PP16DR-Organization.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-02T01:00:00.000+01:00"
-  * profile[as-dr-canonical] = Canonical(as-dr-organization)
+  * profile[as-dr-canonical] = Canonical(as-dr-organization|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-organization|2.2.0"
 // Actif
 * active = true

--- a/input/fsh/examples/DR/PP16DR-Organization.fsh
+++ b/input/fsh/examples/DR/PP16DR-Organization.fsh
@@ -38,7 +38,7 @@ Usage: #example
   * type
     * coding[+]
       * system = "https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203"
-      * code = #INTRN
+      * code = #RPPSRG
 
 
 * telecom[mailbox-mss]

--- a/input/fsh/examples/DR/PP16DR-Organization.fsh
+++ b/input/fsh/examples/DR/PP16DR-Organization.fsh
@@ -12,7 +12,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-02T01:00:00.000+01:00"
   * profile[as-dr-canonical] = Canonical(as-dr-organization)
-  * profile[fr-canonical] = Canonical(fr-core-organization)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-organization|2.2.0"
 // Actif
 * active = true
 

--- a/input/fsh/examples/DR/PP16DR-Organization.fsh
+++ b/input/fsh/examples/DR/PP16DR-Organization.fsh
@@ -11,6 +11,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-02T01:00:00.000+01:00"
+  * profile[as-dr-canonical] = Canonical(as-dr-organization)
+  * profile[fr-canonical] = Canonical(fr-core-organization)
 // Actif
 * active = true
 

--- a/input/fsh/examples/DR/PP16DR-Practitioner.fsh
+++ b/input/fsh/examples/DR/PP16DR-Practitioner.fsh
@@ -11,6 +11,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-08-31T01:00:00.000+01:00"
+  * profile[as-dr-canonical] = Canonical(as-dr-practitioner)
+  * profile[fr-canonical] = Canonical(fr-core-practitioner)
 
 
 * extension[as-ext-registration]

--- a/input/fsh/examples/DR/PP16DR-Practitioner.fsh
+++ b/input/fsh/examples/DR/PP16DR-Practitioner.fsh
@@ -12,7 +12,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-08-31T01:00:00.000+01:00"
   * profile[as-dr-canonical] = Canonical(as-dr-practitioner)
-  * profile[fr-canonical] = Canonical(fr-core-practitioner)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner|2.2.0"
 
 
 * extension[as-ext-registration]

--- a/input/fsh/examples/DR/PP16DR-Practitioner.fsh
+++ b/input/fsh/examples/DR/PP16DR-Practitioner.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-08-31T01:00:00.000+01:00"
-  * profile[as-dr-canonical] = Canonical(as-dr-practitioner)
+  * profile[as-dr-canonical] = Canonical(as-dr-practitioner|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner|2.2.0"
 
 

--- a/input/fsh/examples/DR/PP16DR-PractitionerRole.fsh
+++ b/input/fsh/examples/DR/PP16DR-PractitionerRole.fsh
@@ -13,7 +13,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-08-31T01:00:00.000+01:00"
-  * profile[as-dr-canonical] = Canonical(as-dr-practitionerrole)
+  * profile[as-dr-canonical] = Canonical(as-dr-practitionerrole|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner-role|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DR/PP16DR-PractitionerRole.fsh
+++ b/input/fsh/examples/DR/PP16DR-PractitionerRole.fsh
@@ -14,7 +14,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-08-31T01:00:00.000+01:00"
   * profile[as-dr-canonical] = Canonical(as-dr-practitionerrole)
-  * profile[fr-canonical] = Canonical(fr-core-practitioner-role)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner-role|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DR/PP16DR-PractitionerRole.fsh
+++ b/input/fsh/examples/DR/PP16DR-PractitionerRole.fsh
@@ -13,6 +13,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-08-31T01:00:00.000+01:00"
+  * profile[as-dr-canonical] = Canonical(as-dr-practitionerrole)
+  * profile[fr-canonical] = Canonical(fr-core-practitioner-role)
 
 // Actif
 * active = true

--- a/input/fsh/examples/DR/PP19DR-Organization-EG-CH.fsh
+++ b/input/fsh/examples/DR/PP19DR-Organization-EG-CH.fsh
@@ -11,6 +11,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-01T01:00:00.000+01:00"
+  * profile[as-dr-canonical] = Canonical(as-dr-organization)
+  * profile[fr-canonical] = Canonical(fr-core-organization)
 
 // Actif
 * active = true

--- a/input/fsh/examples/DR/PP19DR-Organization-EG-CH.fsh
+++ b/input/fsh/examples/DR/PP19DR-Organization-EG-CH.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-01T01:00:00.000+01:00"
-  * profile[as-dr-canonical] = Canonical(as-dr-organization)
+  * profile[as-dr-canonical] = Canonical(as-dr-organization|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-organization|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DR/PP19DR-Organization-EG-CH.fsh
+++ b/input/fsh/examples/DR/PP19DR-Organization-EG-CH.fsh
@@ -39,7 +39,7 @@ Usage: #example
   * type
     * coding[+]
       * system = "https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203"
-      * code = #INTRN
+      * code = #RPPSRG
 
 // Nom
 * name = "CH EURE-SEINE"

--- a/input/fsh/examples/DR/PP19DR-Organization-EG-CH.fsh
+++ b/input/fsh/examples/DR/PP19DR-Organization-EG-CH.fsh
@@ -12,7 +12,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-01T01:00:00.000+01:00"
   * profile[as-dr-canonical] = Canonical(as-dr-organization)
-  * profile[fr-canonical] = Canonical(fr-core-organization)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-organization|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DR/PP19DR-Organization-EJ-Cab.fsh
+++ b/input/fsh/examples/DR/PP19DR-Organization-EJ-Cab.fsh
@@ -11,6 +11,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-01T01:00:00.000+01:00"
+  * profile[as-dr-canonical] = Canonical(as-dr-organization)
+  * profile[fr-canonical] = Canonical(fr-core-organization)
 
 // Actif
 * active = true

--- a/input/fsh/examples/DR/PP19DR-Organization-EJ-Cab.fsh
+++ b/input/fsh/examples/DR/PP19DR-Organization-EJ-Cab.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-01T01:00:00.000+01:00"
-  * profile[as-dr-canonical] = Canonical(as-dr-organization)
+  * profile[as-dr-canonical] = Canonical(as-dr-organization|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-organization|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DR/PP19DR-Organization-EJ-Cab.fsh
+++ b/input/fsh/examples/DR/PP19DR-Organization-EJ-Cab.fsh
@@ -31,7 +31,7 @@ Usage: #example
   * type
     * coding[+]
       * system = "https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203"
-      * code = #INTRN
+      * code = #RPPSRG
 
 // Nom
 * name = "CABINET SAINT ANTOINE"

--- a/input/fsh/examples/DR/PP19DR-Organization-EJ-Cab.fsh
+++ b/input/fsh/examples/DR/PP19DR-Organization-EJ-Cab.fsh
@@ -12,7 +12,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-01T01:00:00.000+01:00"
   * profile[as-dr-canonical] = Canonical(as-dr-organization)
-  * profile[fr-canonical] = Canonical(fr-core-organization)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-organization|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DR/PP19DR-Practitioner.fsh
+++ b/input/fsh/examples/DR/PP19DR-Practitioner.fsh
@@ -12,7 +12,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
   * profile[as-dr-canonical] = Canonical(as-dr-practitioner)
-  * profile[fr-canonical] = Canonical(fr-core-practitioner)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DR/PP19DR-Practitioner.fsh
+++ b/input/fsh/examples/DR/PP19DR-Practitioner.fsh
@@ -11,6 +11,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
+  * profile[as-dr-canonical] = Canonical(as-dr-practitioner)
+  * profile[fr-canonical] = Canonical(fr-core-practitioner)
 
 // Actif
 * active = true

--- a/input/fsh/examples/DR/PP19DR-Practitioner.fsh
+++ b/input/fsh/examples/DR/PP19DR-Practitioner.fsh
@@ -11,7 +11,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
-  * profile[as-dr-canonical] = Canonical(as-dr-practitioner)
+  * profile[as-dr-canonical] = Canonical(as-dr-practitioner|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DR/PP19DR-PractitionerRole-Lib.fsh
+++ b/input/fsh/examples/DR/PP19DR-PractitionerRole-Lib.fsh
@@ -14,7 +14,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
   * profile[as-dr-canonical] = Canonical(as-dr-practitionerrole)
-  * profile[fr-canonical] = Canonical(fr-core-practitioner-role)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner-role|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DR/PP19DR-PractitionerRole-Lib.fsh
+++ b/input/fsh/examples/DR/PP19DR-PractitionerRole-Lib.fsh
@@ -13,7 +13,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
-  * profile[as-dr-canonical] = Canonical(as-dr-practitionerrole)
+  * profile[as-dr-canonical] = Canonical(as-dr-practitionerrole|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner-role|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DR/PP19DR-PractitionerRole-Lib.fsh
+++ b/input/fsh/examples/DR/PP19DR-PractitionerRole-Lib.fsh
@@ -13,6 +13,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
+  * profile[as-dr-canonical] = Canonical(as-dr-practitionerrole)
+  * profile[fr-canonical] = Canonical(fr-core-practitioner-role)
 
 // Actif
 * active = true

--- a/input/fsh/examples/DR/PP19DR-PractitionerRole-Sal.fsh
+++ b/input/fsh/examples/DR/PP19DR-PractitionerRole-Sal.fsh
@@ -14,7 +14,7 @@ Usage: #example
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
   * profile[as-dr-canonical] = Canonical(as-dr-practitionerrole)
-  * profile[fr-canonical] = Canonical(fr-core-practitioner-role)
+  * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner-role|2.2.0"
 
 // Actif
 * active = true

--- a/input/fsh/examples/DR/PP19DR-PractitionerRole-Sal.fsh
+++ b/input/fsh/examples/DR/PP19DR-PractitionerRole-Sal.fsh
@@ -13,7 +13,7 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
-  * profile[as-dr-canonical] = Canonical(as-dr-practitionerrole)
+  * profile[as-dr-canonical] = Canonical(as-dr-practitionerrole|1.2.0-snapshot-2)
   * profile[fr-canonical] = "https://hl7.fr/ig/fhir/core/StructureDefinition/fr-core-practitioner-role|2.2.0"
 
 // Actif

--- a/input/fsh/examples/DR/PP19DR-PractitionerRole-Sal.fsh
+++ b/input/fsh/examples/DR/PP19DR-PractitionerRole-Sal.fsh
@@ -13,6 +13,8 @@ Usage: #example
   * versionId = "0.1"
   * source = "https://annuaire.esante.gouv.fr"
   * lastUpdated = "2019-09-05T01:00:00.000+01:00"
+  * profile[as-dr-canonical] = Canonical(as-dr-practitionerrole)
+  * profile[fr-canonical] = Canonical(fr-core-practitioner-role)
 
 // Actif
 * active = true

--- a/input/fsh/profiles-dp/AsDpDeviceProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpDeviceProfile.fsh
@@ -9,7 +9,7 @@ Description: """Profil public applicatif créé à partir du profil générique 
 * meta.profile ^slicing.rules = #open
 * meta.profile ^slicing.description = "Slice based on the canonical url value"
 * meta.profile contains as-dp-canonical 1..1
-* meta.profile[as-dp-canonical] = Canonical(as-dp-device)
+* meta.profile[as-dp-canonical] = Canonical(as-dp-device|1.2.0-snapshot-2)
 
 * extension[as-ext-authorization] MS
 * status MS

--- a/input/fsh/profiles-dp/AsDpHealthcareServiceHealthCareActivityProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpHealthcareServiceHealthCareActivityProfile.fsh
@@ -10,7 +10,7 @@ Description: """Profil public applicatif créé à partir du profil générique 
 * meta.profile ^slicing.rules = #open
 * meta.profile ^slicing.description = "Slice based on the canonical url value"
 * meta.profile contains as-dp-canonical 1..1
-* meta.profile[as-dp-canonical] = Canonical(as-dp-healthcareservice-healthcare-activity)
+* meta.profile[as-dp-canonical] = Canonical(as-dp-healthcareservice-healthcare-activity|1.2.0-snapshot-2)
 
 * extension[as-ext-authorization] MS
 * identifier[numAutorisationArhgos] MS

--- a/input/fsh/profiles-dp/AsDpHealthcareServiceSocialEquipmentProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpHealthcareServiceSocialEquipmentProfile.fsh
@@ -9,7 +9,7 @@ Description: """Profil public applicatif créé à partir du profil générique 
 * meta.profile ^slicing.rules = #open
 * meta.profile ^slicing.description = "Slice based on the canonical url value"
 * meta.profile contains as-dp-canonical 1..1
-* meta.profile[as-dp-canonical] = Canonical(as-dp-healthcareservice-social-equipment)
+* meta.profile[as-dp-canonical] = Canonical(as-dp-healthcareservice-social-equipment|1.2.0-snapshot-2)
 
 * extension[as-ext-authorization] MS
 * extension[as-ext-installation] MS

--- a/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh
@@ -20,7 +20,6 @@ Description: """Profil public applicatif créé à partir du profil générique 
 * identifier[finess] MS
 * identifier[siren] MS
 * identifier[siret] MS
-* identifier[adeliRang] MS
 * active MS
 * name MS
 * alias MS

--- a/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpOrganizationProfile.fsh
@@ -5,7 +5,7 @@ Title: "AS Donnée Publique Organization Profile"
 Description: """Profil public applicatif créé à partir du profil générique as-organization  dans le contexte des données en libre accès de l’Annuaire Santé. Pour connaître les paramètres de recherches associés à ce profil, il suffit de consulter le CapabilityStatement AsServerCapabilityStatement."""
 
 * meta.profile contains as-dp-canonical 1..1
-* meta.profile[as-dp-canonical] = Canonical(as-dp-organization)
+* meta.profile[as-dp-canonical] = Canonical(as-dp-organization|1.2.0-snapshot-2)
 * meta.profile[fr-canonical] 1..1
 
 * extension[as-ext-digital-certificate] MS

--- a/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
@@ -5,7 +5,7 @@ Title:			"AS Donnée Publique Practitioner Profile"
 Description: 	"""Profil public applicatif créé à partir du profil générique as-practitioner dans le contexte des données en libre accès de l’Annuaire Santé. Pour connaître les paramètres de recherches associés à ce profil, il suffit de consulter le CapabilityStatement AsServerCapabilityStatement."""
 
 * meta.profile contains as-dp-canonical 1..1
-* meta.profile[as-dp-canonical] = Canonical(as-dp-practitioner)
+* meta.profile[as-dp-canonical] = Canonical(as-dp-practitioner|1.2.0-snapshot-2)
 * meta.profile[fr-canonical] 1..1
 
 // extensions

--- a/input/fsh/profiles-dp/AsDpPractitionerRoleProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpPractitionerRoleProfile.fsh
@@ -5,7 +5,7 @@ Title:			"AS Donnée Publique PractitionerRole Profile"
 Description: 	"""Profil public applicatif créé à partir du profil générique as-practitionerrole dans le contexte des données en libre accès de l’Annuaire Santé. Pour connaître les paramètres de recherches associés à ce profil, il suffit de consulter le CapabilityStatement AsServerCapabilityStatement."""
 
 * meta.profile contains as-dp-canonical 1..1
-* meta.profile[as-dp-canonical] = Canonical(as-dp-practitionerrole)
+* meta.profile[as-dp-canonical] = Canonical(as-dp-practitionerrole|1.2.0-snapshot-2)
 * meta.profile[fr-canonical] 1..1
 
 * extension[as-ext-practitionerrole-contracted] 0..0

--- a/input/fsh/profiles-dr/AsDrDeviceProfile.fsh
+++ b/input/fsh/profiles-dr/AsDrDeviceProfile.fsh
@@ -10,7 +10,7 @@ Description: "Profil restreint applicatif créé à partir du profil générique
 * meta.profile ^slicing.rules = #open
 * meta.profile ^slicing.description = "Slice based on the canonical url value"
 * meta.profile contains as-dr-canonical 1..1
-* meta.profile[as-dr-canonical] = Canonical(as-dr-device)
+* meta.profile[as-dr-canonical] = Canonical(as-dr-device|1.2.0-snapshot-2)
 
 * extension[as-ext-authorization] MS
 * identifier MS

--- a/input/fsh/profiles-dr/AsDrHealthcareServiceHealthCareActivityProfile.fsh
+++ b/input/fsh/profiles-dr/AsDrHealthcareServiceHealthCareActivityProfile.fsh
@@ -9,7 +9,7 @@ Description: "Profil restreint applicatif créé à partir du profil générique
 * meta.profile ^slicing.rules = #open
 * meta.profile ^slicing.description = "Slice based on the canonical url value"
 * meta.profile contains as-dr-canonical 1..1
-* meta.profile[as-dr-canonical] = Canonical(as-dr-healthcareservice-healthcare-activity)
+* meta.profile[as-dr-canonical] = Canonical(as-dr-healthcareservice-healthcare-activity|1.2.0-snapshot-2)
 
 * extension[as-ext-authorization] MS
 * identifier[numAutorisationArhgos] MS

--- a/input/fsh/profiles-dr/AsDrHealthcareServiceSocialEquipmentProfile.fsh
+++ b/input/fsh/profiles-dr/AsDrHealthcareServiceSocialEquipmentProfile.fsh
@@ -9,7 +9,7 @@ Description: "Profil restreint applicatif créé à partir du profil générique
 * meta.profile ^slicing.rules = #open
 * meta.profile ^slicing.description = "Slice based on the canonical url value"
 * meta.profile contains as-dr-canonical 1..1
-* meta.profile[as-dr-canonical] = Canonical(as-dr-healthcareservice-social-equipment)
+* meta.profile[as-dr-canonical] = Canonical(as-dr-healthcareservice-social-equipment|1.2.0-snapshot-2)
 
 * extension[as-ext-authorization] MS
 * extension[as-ext-installation] MS

--- a/input/fsh/profiles-dr/AsDrOrganizationProfile.fsh
+++ b/input/fsh/profiles-dr/AsDrOrganizationProfile.fsh
@@ -5,7 +5,7 @@ Title: "AS Donnée Restreinte Organization Profile"
 Description: "Profil restreint créé à partir de as-organization  dans le contexte des données en accès restreint de l’Annuaire Santé."
 
 * meta.profile contains as-dr-canonical 1..1
-* meta.profile[as-dr-canonical] = Canonical(as-dr-organization)
+* meta.profile[as-dr-canonical] = Canonical(as-dr-organization|1.2.0-snapshot-2)
 * meta.profile[fr-canonical] 1..1
 
 * identifier[idNatSt] MS 

--- a/input/fsh/profiles-dr/AsDrPerson.fsh
+++ b/input/fsh/profiles-dr/AsDrPerson.fsh
@@ -9,7 +9,7 @@ Description: 	"Profil restreint créé à partir de as-person dans le contexte d
 * meta.profile ^slicing.rules = #open
 * meta.profile ^slicing.description = "Slice based on the canonical url value"
 * meta.profile contains as-dr-canonical 1..1
-* meta.profile[as-dr-canonical] = Canonical(as-dr-person)
+* meta.profile[as-dr-canonical] = Canonical(as-dr-person|1.2.0-snapshot-2)
 
 * extension[as-ext-person-birth-place] MS
 * extension[as-ext-person-deceased-date-time] MS

--- a/input/fsh/profiles-dr/AsDrPractitionerProfile.fsh
+++ b/input/fsh/profiles-dr/AsDrPractitionerProfile.fsh
@@ -5,7 +5,7 @@ Title:			"AS Donnée Restreinte Practitioner Profile"
 Description: 	"Profil restreint créé à partir de as-practitioner dans le contexte des données en accès restreint de l’Annuaire Santé."
 
 * meta.profile contains as-dr-canonical 1..1
-* meta.profile[as-dr-canonical] = Canonical(as-dr-practitioner)
+* meta.profile[as-dr-canonical] = Canonical(as-dr-practitioner|1.2.0-snapshot-2)
 * meta.profile[fr-canonical] 1..1
 
 * extension[as-ext-registration] MS

--- a/input/fsh/profiles-dr/AsDrPractitionerProfile.fsh
+++ b/input/fsh/profiles-dr/AsDrPractitionerProfile.fsh
@@ -22,7 +22,7 @@ Description: 	"Profil restreint créé à partir de as-practitioner dans le cont
 
 * qualification contains attributionParticuliere 0..*
 
-* qualification[attributionParticuliere].code from https://mos.esante.gouv.fr/NOS/JDV_J90-AttributionParticuliere-RASS/FHIR/JDV-J90-AttributionParticuliere-RASS (required) 
+* qualification[attributionParticuliere].code.coding from https://mos.esante.gouv.fr/NOS/JDV_J90-AttributionParticuliere-RASS/FHIR/JDV-J90-AttributionParticuliere-RASS (required)
 * qualification[attributionParticuliere].code MS
 
 * qualification[attributionParticuliere].period MS

--- a/input/fsh/profiles-dr/AsDrPractitionerRoleProfile.fsh
+++ b/input/fsh/profiles-dr/AsDrPractitionerRoleProfile.fsh
@@ -5,7 +5,7 @@ Title:			"AS Donnée Restreinte PractitionerRole Profile"
 Description: 	"Profil restreint créé à partir de as-practitionerrole dans le contexte des données en accès restreint de l’Annuaire Santé."
 
 * meta.profile contains as-dr-canonical 1..1
-* meta.profile[as-dr-canonical] = Canonical(as-dr-practitionerrole)
+* meta.profile[as-dr-canonical] = Canonical(as-dr-practitionerrole|1.2.0-snapshot-2)
 * meta.profile[fr-canonical] 1..1
 
 * practitioner MS 

--- a/input/fsh/profiles/AsOrganizationProfile.fsh
+++ b/input/fsh/profiles/AsOrganizationProfile.fsh
@@ -4,7 +4,48 @@ Id: as-organization
 Title: "AS Organization Profile"
 Description: "Profil générique créé à partir de FrOrganization dans le contexte de l'Annuaire Santé pour décrire les établissements sanitaires, sociaux et médico-sociaux immatriculés dans le FIchier National des Etablissements Sanitaires et Sociaux (FINESS) ou dans le Répertoire Partagé des Professionnels de Santé (RPPS)."
 
-* identifier.type ^short = "Type d’identifiant national de l'organisation"
+* identifier.type ^short = "Type d’identifiant national de l’organisation"
+
+// Identifiants - slicing repris de FRCoreOrganizationProfile 2.1.0 (déplacé dans FRCoreOrganizationEtablissementProfile en 2.2.0)
+* identifier.use from IdentifierUse (required)
+* identifier.type from FRCoreValueSetOrganizationIdentifierType (extensible)
+
+* identifier ^slicing.discriminator[0].type = #pattern
+* identifier ^slicing.discriminator[0].path = "system"
+* identifier ^slicing.discriminator[1].type = #pattern
+* identifier ^slicing.discriminator[1].path = "type"
+* identifier ^slicing.rules = #open
+* identifier ^slicing.description = "Slice based on the identifier.system pattern"
+
+* identifier contains
+    idNatSt 0..* and
+    siren 0..* and
+    siret 0..* and
+    finess 0..* and
+    rppsRang 0..*
+
+* identifier[idNatSt] ^short = "Identifiant national de structure, à privilégier. Identifiant idNat_Struct délivré par une autorité d’enregistrement tel que défini dans l’Annexe Transverse Source des données métier pour les professionnels et les structures."
+* identifier[idNatSt].use = #official
+* identifier[idNatSt].type = https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203#IDNST
+* identifier[idNatSt].system = "urn:oid:1.2.250.1.71.4.2.2"
+* identifier[idNatSt].value ^short = "Identification nationale de la structure préfixée : 0 + ADELI rang, 1 + Numéro FINESS Etablissement, 2 + Numéro SIREN, 3 + Numéro SIRET, 4 + RPPS rang ou identifiant technique de la structure."
+
+* identifier[siren] ^short = "Identifiant SIREN (9 chiffres)"
+* identifier[siren].type = https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203#SIREN
+* identifier[siren].system = "https://sirene.fr"
+
+* identifier[siret] ^short = "Identifiant SIRET (14 chiffres)"
+* identifier[siret].type = https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203#SIRET
+* identifier[siret].system = "https://sirene.fr"
+
+* identifier[finess] ^short = "Identifiant FINESS Entité Géographique (EG) ou Entité Juridique (EJ)"
+* identifier[finess].type.coding.code ^short = "FINEJ | FINEG"
+* identifier[finess].type.coding.system = "https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203"
+* identifier[finess].system = "https://finess.esante.gouv.fr"
+
+* identifier[rppsRang] ^short = "RPPS rang (11 chiffres RPPS + 2 ou 3 chiffres RANG)"
+* identifier[rppsRang].type = https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203#RPPSRG
+* identifier[rppsRang].system = "https://rppsrang.esante.gouv.fr"
 
 // Organization.active
 * active ^short = "La ressource est-elle active ? (active | inactive). true par défaut; false pour les structures supprimées."
@@ -16,16 +57,38 @@ Description: "Profil générique créé à partir de FrOrganization dans le cont
 * alias ^short = "Enseigne commerciale de la structure (Synonyme : complementRaisonSociale)."
 
 /* champ d'activite de la structure */
-// Slice de FrCoreOrganization
+// Slices de FrCoreOrganizationProfile 2.1.0 (supprimées en 2.2.0, redéfinies ici)
+* type ^slicing.discriminator.type = #value
+* type ^slicing.discriminator.path = "$this"
+* type ^slicing.rules = #open
+
 * type contains
-    statutJuridiqueINSEE 0..1 and 
+    organizationType 0..1 and
+    secteurActiviteRASS 0..1 and
+    categorieEtablissementRASS 0..1 and
+    statutJuridiqueINSEE 0..1 and
     sphParticipation 0..1 and
     typeEtablissement 0..1
 
-// organizationType - slice de FrCoreOrganization
+// organizationType
+* type[organizationType] from FRCoreValueSetOrganizationType (required)
+* type[organizationType].coding 1..1
+* type[organizationType].coding.system 1..
 * type[organizationType] ^short = "Type de structure \r\nEntité Juridique : LEGAL-ENTITY; \r\nEntité Géographique : GEOGRAPHICAL-ENTITY"
 * type[organizationType].extension contains as-ext-organization-types named as-ext-organization-types 1..1
 * type[organizationType].extension[as-ext-organization-types].valueCode = #organizationType
+
+// secteurActiviteRASS
+* type[secteurActiviteRASS] from $JDV-J101-SecteurActivite-RASS (required)
+* type[secteurActiviteRASS] ^short = "Secteurs d'activité des établissements avec la même activité dans le RASS"
+* type[secteurActiviteRASS].coding 1..1
+* type[secteurActiviteRASS].coding.system 1..
+
+// categorieEtablissementRASS
+* type[categorieEtablissementRASS] from $JDV-J129-CategorieEtablissement-RASS (required)
+* type[categorieEtablissementRASS] ^short = "Catégorie d'établissement du RASS"
+* type[categorieEtablissementRASS].coding 1..1
+* type[categorieEtablissementRASS].coding.system 1..
 
 
 // statutJuridiqueINSEE
@@ -106,7 +169,6 @@ Title:    "AsOrganization to MOS - EJ"
 * identifier[finess] -> "EntiteJuridique.numFiness"
 * identifier[siren] -> "EntiteJuridique.numSiren"
 * identifier[idNatSt] -> "EntiteJuridique.idNat_struct"
-* identifier[adeliRang] -> "EntiteGeographique.identifiantEJ"
 * identifier[rppsRang] -> "EntiteGeographique.identifiantEJ"
 * extension[as-ext-organization-pharmacy-licence] -> "EntiteJuridique.numeroLicenceOfficine"
 * name  -> "EntiteJuridique.raisonSociale"
@@ -129,7 +191,6 @@ Title:    "AsOrganization to MOS - EG"
 * identifier[siren] -> "EntiteGeographique.numSiren"
 * identifier[siret] -> "EntiteGeographique.numSiret"
 * identifier[idNatSt] -> "EntiteGeographique.idNat_struct"
-* identifier[adeliRang] -> "EntiteGeographique.identifiantEG"
 * identifier[rppsRang] -> "EntiteGeographique.identifiantEG"
 
 * active -> "EntiteGeographique.actof"

--- a/input/fsh/profiles/AsOrganizationProfile.fsh
+++ b/input/fsh/profiles/AsOrganizationProfile.fsh
@@ -1,51 +1,10 @@
 Profile: AsOrganizationProfile
-Parent: fr-core-organization
+Parent: fr-core-organization-etablissement
 Id: as-organization
 Title: "AS Organization Profile"
 Description: "Profil générique créé à partir de FrOrganization dans le contexte de l'Annuaire Santé pour décrire les établissements sanitaires, sociaux et médico-sociaux immatriculés dans le FIchier National des Etablissements Sanitaires et Sociaux (FINESS) ou dans le Répertoire Partagé des Professionnels de Santé (RPPS)."
 
 * identifier.type ^short = "Type d’identifiant national de l’organisation"
-
-// Identifiants - slicing repris de FRCoreOrganizationProfile 2.1.0 (déplacé dans FRCoreOrganizationEtablissementProfile en 2.2.0)
-* identifier.use from IdentifierUse (required)
-* identifier.type from FRCoreValueSetOrganizationIdentifierType (extensible)
-
-* identifier ^slicing.discriminator[0].type = #pattern
-* identifier ^slicing.discriminator[0].path = "system"
-* identifier ^slicing.discriminator[1].type = #pattern
-* identifier ^slicing.discriminator[1].path = "type"
-* identifier ^slicing.rules = #open
-* identifier ^slicing.description = "Slice based on the identifier.system pattern"
-
-* identifier contains
-    idNatSt 0..* and
-    siren 0..* and
-    siret 0..* and
-    finess 0..* and
-    rppsRang 0..*
-
-* identifier[idNatSt] ^short = "Identifiant national de structure, à privilégier. Identifiant idNat_Struct délivré par une autorité d’enregistrement tel que défini dans l’Annexe Transverse Source des données métier pour les professionnels et les structures."
-* identifier[idNatSt].use = #official
-* identifier[idNatSt].type = https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203#IDNST
-* identifier[idNatSt].system = "urn:oid:1.2.250.1.71.4.2.2"
-* identifier[idNatSt].value ^short = "Identification nationale de la structure préfixée : 0 + ADELI rang, 1 + Numéro FINESS Etablissement, 2 + Numéro SIREN, 3 + Numéro SIRET, 4 + RPPS rang ou identifiant technique de la structure."
-
-* identifier[siren] ^short = "Identifiant SIREN (9 chiffres)"
-* identifier[siren].type = https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203#SIREN
-* identifier[siren].system = "https://sirene.fr"
-
-* identifier[siret] ^short = "Identifiant SIRET (14 chiffres)"
-* identifier[siret].type = https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203#SIRET
-* identifier[siret].system = "https://sirene.fr"
-
-* identifier[finess] ^short = "Identifiant FINESS Entité Géographique (EG) ou Entité Juridique (EJ)"
-* identifier[finess].type.coding.code ^short = "FINEJ | FINEG"
-* identifier[finess].type.coding.system = "https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203"
-* identifier[finess].system = "https://finess.esante.gouv.fr"
-
-* identifier[rppsRang] ^short = "RPPS rang (11 chiffres RPPS + 2 ou 3 chiffres RANG)"
-* identifier[rppsRang].type = https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203#RPPSRG
-* identifier[rppsRang].system = "https://rppsrang.esante.gouv.fr"
 
 // Organization.active
 * active ^short = "La ressource est-elle active ? (active | inactive). true par défaut; false pour les structures supprimées."

--- a/input/fsh/profiles/AsPractitionerProfile.fsh
+++ b/input/fsh/profiles/AsPractitionerProfile.fsh
@@ -20,13 +20,6 @@ Description: 	"Profil générique créé à partir de FrPractitioner dans le con
 
 * identifier.type ^short = "Type d’identifiant national de la personne physique (typeIdNat_PP),\r\nLes codes RPPS et IDNPS proviennent du system  https://hl7.fr/ig/fhir/core/CodeSystem/fr-core-cs-v2-0203 ; Les codes 1, 3, 4, 5, 6 proviennent du system : https://mos.esante.gouv.fr/NOS/TRE_G08-TypeIdentifiantPersonne/FHIR/TRE-G08-TypeIdentifiantPersonne"
 
-* identifier[idNatPs].type 1..1 // Contrainte ajoutée dans FrCore, ligne à supprimer à la prochaine release de FrCore 
-
-* identifier[rpps].type 1..1 // Contrainte ajoutée dans FrCore, ligne à supprimer à la prochaine release de FrCore 
-
-* identifier[adeli] 0..0 // Adeli décommissionné, ligne à supprimer au prochain héritage FrCore 
-
-
 // Practitioner.active
 * active ^short = "Cette ressource est-elle active ?\ntrue  par défaut; false pour indiquer que la ressource a été supprimée"
 

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -1,5 +1,13 @@
 ### Release 1.2.0 de l'Implementation Guide Annuaire
 
+#### 1.2.0-snapshot-2
+
+* Mise à jour de la dépendance FRCore vers 2.2.0 (correction issue #289, héritage fr-core-organization-etablissement, suppression ADELI) [#307](https://github.com/ansforge/IG-fhir-annuaire/pull/307)
+* Suppression du profil G13 des données publiques [#304](https://github.com/ansforge/IG-fhir-annuaire/pull/304)
+* BAL MSSanté : ajout Swagger et préférence BAL [#306](https://github.com/ansforge/IG-fhir-annuaire/pull/306)
+
+#### 1.2.0-snapshot-1
+
 Modifications apportées dans la [1.2.0](https://github.com/ansforge/IG-fhir-annuaire/pulls?q=is%3Apr+is%3Aclosed+milestone%3A1.2.0) :
 
 * Mise à jour vers le nouveau template HL7 [302](https://github.com/ansforge/IG-fhir-annuaire/pull/302)

--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -1,14 +1,14 @@
-L'implementation guide contient un package [téléchargeable ici](package.tgz) permettant de valider les instances par rapport aux profils qu'il contient.
+L'implementation guide contient un package [téléchargeable ici](../package.tgz) permettant de valider les instances par rapport aux profils qu'il contient.
 
-Pour cela, il suffit de télécharger le [package.tgz](package.tgz) et l'importer dans un serveur, par exemple sur hapi en suivant ce [script python](https://github.com/nmdp-bioinformatics/igloader) open source.
+Pour cela, il suffit de télécharger le [package.tgz](../package.tgz) et l'importer dans un serveur, par exemple sur hapi en suivant ce [script python](https://github.com/nmdp-bioinformatics/igloader) open source.
 
 Vous pourrez ensuite utiliser l'opération [$validate](https://www.hl7.org/fhir/resource-operation-validate.html) pour valider les instances de ressource contre un profil issu de cette spécification.
 
 Ensemble des ressources téléchargeables : 
 
-* [L'ensemble de la specification (zip)](full-ig.zip)
-* [Package (tgz)](package.tgz)
-* [JSON Définitions (zip)](definitions.json.zip)
-* [JSON Exemples (zip)](examples.json.zip)
-* [XML Definitions (zip)](definitions.xml.zip)
-* [XML Exemples (zip)](examples.xml.zip)
+* [L'ensemble de la specification (zip)](../full-ig.zip)
+* [Package (tgz)](../package.tgz)
+* [JSON Définitions (zip)](../definitions.json.zip)
+* [JSON Exemples (zip)](../examples.json.zip)
+* [XML Definitions (zip)](../definitions.xml.zip)
+* [XML Exemples (zip)](../examples.xml.zip)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -10,7 +10,7 @@ publisher:
   url: https://esante.gouv.fr
   email: monserviceclient.annuaire@esante.gouv.fr
 dependencies:
-  hl7.fhir.fr.core: 2.1.0
+  hl7.fhir.fr.core: 2.2.0
   hl7.fhir.uv.xver-r5.r4: latest
   ans.fr.terminologies: latest
   hl7.terminology.r4: 5.5.0

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -15,7 +15,7 @@ dependencies:
   ans.fr.terminologies: latest
   hl7.terminology.r4: 5.5.0
 status: draft
-version: 1.2.0-snapshot-1
+version: 1.2.0-snapshot-2
 fhirVersion: 4.0.1
 copyrightYear: 2020+
 # releaseLabel: final-text


### PR DESCRIPTION
## Description des changements

* `sushi-config.yaml` : mise à jour de la dépendance `hl7.fhir.fr.core` de `2.1.0` à `2.2.0`
* `AsOrganizationProfile` : les slices `identifier` (idNatSt, siren, siret, finess, rppsRang) et les slices `type` RASS (organizationType, secteurActiviteRASS, categorieEtablissementRASS) étaient définies dans `fr-core-organization` 2.1.0 — elles ont été déplacées dans `FRCoreOrganizationEtablissementProfile` en 2.2.0 et sont donc redéfinies ici
* `AsOrganizationProfile` : suppression du mapping `identifier[adeliRang]` (ADELI décommissionné nationalement, slice supprimée de FRCore en 2.2.0)
* `AsDpOrganizationProfile` : suppression de `identifier[adeliRang] MS`
* `AsPractitionerProfile` : nettoyage des workarounds devenus natifs dans FRCore 2.2.0 (`identifier[adeli] 0..0`, `identifier[idNatPs].type 1..1`, `identifier[rpps].type 1..1`)
* `aliases.fsh` : ajout de l'alias `$JDV-J129-CategorieEtablissement-RASS`

Closes #289

## Preview

https://build.fhir.org/ig/ansforge/IG-fhir-annuaire/branches/nr-update-frcore-2.2.0

https://ansforge.github.io/IG-fhir-annuaire/nr-update-frcore-2.2.0/ig/