### PR TITLE
feat: traduction anglaise automatique des pages du guide

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,11 +1,5 @@
 ### Introduction
 
-<p style="padding: 5px; border-radius: 5px; border: 2px solid maroon; background: #ffffe6; width: 65%">
-<b>Healthcare professional Directory Implementation Guide</b><br>
-This implementation guide contains the FHIR profiles of French Healthcare professionals directory and documents how the data are exposed in the national API.
-</p>
-
-
 {% if site.data.info.releaselabel == 'ci-build' %}
 <div style="width: 65%">
 <blockquote class="stu-note">

--- a/input/pagecontent/translationinfo.md
+++ b/input/pagecontent/translationinfo.md
@@ -1,1 +1,5 @@
-Ce document contient les informations sur les traductions.
+### Informations sur la traduction
+
+Ce guide d'implémentation est rédigé en français. La version française est la version de référence officielle.
+
+Une traduction anglaise est disponible à titre indicatif. Cette traduction a été générée automatiquement par intelligence artificielle et n'a pas fait l'objet d'une relecture par les auteurs du guide. En cas de divergence entre la version française et la version anglaise, la version française prévaut.

--- a/input/translations/en/pagecontent/changes.md
+++ b/input/translations/en/pagecontent/changes.md
@@ -1,0 +1,86 @@
+### Release 1.2.0 of the Annuaire Implementation Guide
+
+Changes included in [1.2.0](https://github.com/ansforge/IG-fhir-annuaire/pulls?q=is%3Apr+is%3Aclosed+milestone%3A1.2.0):
+
+* Migration to the new HL7 template [302](https://github.com/ansforge/IG-fhir-annuaire/pull/302)
+* BAL MSSanté: removal of dematerialisation and phone fields [301](https://github.com/ansforge/IG-fhir-annuaire/pull/301)
+* MS tag on slices rather than on the base attribute (DP profiles) [300](https://github.com/ansforge/IG-fhir-annuaire/pull/300)
+* MS tag on slices rather than on the general attribute for DP PractitionerRole profile [299](https://github.com/ansforge/IG-fhir-annuaire/pull/299)
+* Addition of search parameter for BAL MSSanté type [296](https://github.com/ansforge/IG-fhir-annuaire/pull/296)
+* Deprecation and replacement of JDV MOS NOS [294](https://github.com/ansforge/IG-fhir-annuaire/pull/294)
+* Addition of identifier type short to AsOrganization profile [290](https://github.com/ansforge/IG-fhir-annuaire/pull/290)
+* Addition of meta.source to applicative profiles [286](https://github.com/ansforge/IG-fhir-annuaire/pull/286)
+* Addition of missing data for the Restricted Data API [285](https://github.com/ansforge/IG-fhir-annuaire/pull/285)
+* Addition of search parameter for organization period [284](https://github.com/ansforge/IG-fhir-annuaire/pull/284)
+* Removal of health insurance number [283](https://github.com/ansforge/IG-fhir-annuaire/pull/283)
+* Relocation of MS (Must Support) tags [282](https://github.com/ansforge/IG-fhir-annuaire/pull/282)
+* Removal of Location profile [281](https://github.com/ansforge/IG-fhir-annuaire/pull/281)
+* Addition of known issues page [280](https://github.com/ansforge/IG-fhir-annuaire/pull/280)
+* Removal of internal identifiers from Organization and Practitioner [278](https://github.com/ansforge/IG-fhir-annuaire/pull/278)
+* Update of generic profile descriptions [276](https://github.com/ansforge/IG-fhir-annuaire/pull/276)
+* Compliance with the new RPPS decree [271](https://github.com/ansforge/IG-fhir-annuaire/pull/271)
+* Update of CapabilityStatement with canonical URLs and modifiers [269](https://github.com/ansforge/IG-fhir-annuaire/pull/269)
+* Creation of CapabilityStatement for the v2 API [268](https://github.com/ansforge/IG-fhir-annuaire/pull/268)
+
+### Release 1.1.0 of the Annuaire Implementation Guide
+
+Changes included in release [1.1.0](https://github.com/ansforge/IG-fhir-annuaire/pulls?q=is%3Apr+is%3Aclosed+milestone%3A1.1.0):
+
+* (1.1.0-snapshot-6) Update of identifier cardinalities for Device, HealthcareService, PractitionerRole (numAutorisationArhgos and idSituationExercice) [258](https://github.com/ansforge/IG-fhir-annuaire/pull/258)
+* (1.1.0-snapshot-6) Removal of Organization.identifier[identifiantInterne], from Practitioner dp: listeRouge boolean and name.period [261](https://github.com/ansforge/IG-fhir-annuaire/pull/261)
+* (1.1.0-snapshot-6) Update of smartcard (rename cancellationDate to oppositionDate and removal of date) [260](https://github.com/ansforge/IG-fhir-annuaire/pull/260)
+* (1.1.0-snapshot-6) Removal of Practitioner internal identifier [259](https://github.com/ansforge/IG-fhir-annuaire/pull/259)
+
+* (1.1.0-snapshot-6) Update JDV Country (from J74 to J256) [258](https://github.com/ansforge/IG-fhir-annuaire/pull/258)
+
+* (1.1.0-snapshot-5) Change of address district JDV and addition of the possibility of having two CPS cards for PractitionerDP [254](https://github.com/ansforge/IG-fhir-annuaire/pull/254)
+* (1.1.0-snapshot-5) Update JDV Country (from J74 to J256) [258](https://github.com/ansforge/IG-fhir-annuaire/pull/258)
+* (1.1.0-snapshot-5) Removal of Practitioner internal identifier [259](https://github.com/ansforge/IG-fhir-annuaire/pull/259)
+* (1.1.0-snapshot-5) Addition of MOS mapping [250](https://github.com/ansforge/IG-fhir-annuaire/pull/250)
+* (1.1.0-snapshot-5) Fix of telecom:mailbox-mss slicing on Practitioner, Organization, PractitionerRole profiles [244](https://github.com/ansforge/IG-fhir-annuaire/pull/244)
+* (1.1.0-snapshot-5) Addition of MS tags on PractitionerDP identifiers [243](https://github.com/ansforge/IG-fhir-annuaire/pull/243)
+* (1.1.0-snapshot-5) Removal of IG-internal JDVs in favour of those defined by NOS [247](https://github.com/ansforge/IG-fhir-annuaire/pull/247)
+
+* (1.1.0-snapshot-4) Addition of CS and VS typeEtablissement with binding (PRIMAIRE / SECONDAIRE) [235](https://github.com/ansforge/IG-fhir-annuaire/pull/235)
+* (1.1.0-snapshot-4) Update of HealthcareService profiles (CODE ACT SOIN, installation date) [233](https://github.com/ansforge/IG-fhir-annuaire/pull/233)
+* (1.1.0-snapshot-4) Removal of ADELI number following national decommissioning [240](https://github.com/ansforge/IG-fhir-annuaire/pull/240)
+
+* (1.1.0-snapshot-3) Addition of missing fields [220](https://github.com/ansforge/IG-fhir-annuaire/pull/220)
+* (1.1.0-snapshot-3) Update of MSS extension context [221](https://github.com/ansforge/IG-fhir-annuaire/pull/221)
+* (1.1.0-snapshot-3) Addition of a missing SP (qualification-code) and fix of canonical URLs in applicative profiles [225](https://github.com/ansforge/IG-fhir-annuaire/pull/225)
+* (1.1.0-snapshot-3) Update of FrCore dependency to 2.1.0 and addition of information on where to find SPs associated with each profile in descriptions [229](https://github.com/ansforge/IG-fhir-annuaire/pull/229)
+* (1.1.0-snapshot-3) Update of MSS metadata to clarify the use of the listeRouge boolean [231](https://github.com/ansforge/IG-fhir-annuaire/pull/231)
+* (1.1.0-snapshot-3) Prohibition on the use of Practitioner.qualification.period [232](https://github.com/ansforge/IG-fhir-annuaire/pull/232)
+
+* (1.1.0-snapshot-2) Update of RPPS & ADELI identifier systems for PractitionerRole [209](https://github.com/ansforge/IG-fhir-annuaire/pull/209)
+* (1.1.0-snapshot-2) Removal of residual interopsante.org URLs [214](https://github.com/ansforge/IG-fhir-annuaire/pull/214)
+* (1.1.0-snapshot-2) Update of AsAuthorizationExtension (name and context change) [211](https://github.com/ansforge/IG-fhir-annuaire/pull/211)
+* (1.1.0-snapshot-2) Addition of a first version of examples [142](https://github.com/ansforge/IG-fhir-annuaire/pull/142)
+* (1.1.0-snapshot-2) Fix of OrganizationType ValueSet [218](https://github.com/ansforge/IG-fhir-annuaire/pull/218)
+* (1.1.0-snapshot-2) Update of FrCore to current version [219](https://github.com/ansforge/IG-fhir-annuaire/pull/219)
+
+* (1.1.0-snapshot) Update of RPPS & ADELI identifier systems for PractitionerRole [209](https://github.com/ansforge/IG-fhir-annuaire/pull/209)
+* (1.1.0-snapshot) Removal of residual interopsante.org URLs [214](https://github.com/ansforge/IG-fhir-annuaire/pull/214)
+* (1.1.0-snapshot) Update of AsAuthorizationExtension (name and context change) [211](https://github.com/ansforge/IG-fhir-annuaire/pull/211)
+* (1.1.0-snapshot) Addition of a first version of examples [142](https://github.com/ansforge/IG-fhir-annuaire/pull/142)
+
+### Release 1.0.1 of the Annuaire Implementation Guide
+
+Changes included in release [1.0.1](https://github.com/ansforge/IG-fhir-annuaire/milestone/6?closed=1):
+
+* Update of FrCore dependency [205](https://github.com/ansforge/IG-fhir-annuaire/pull/205)
+
+### Release 1.0.0 of the Annuaire Implementation Guide
+
+Changes included in release [1.0.0](https://github.com/ansforge/IG-fhir-annuaire/milestone/7?closed=1):
+
+* (1.0.0-ballot-4) IG clean-up [198](https://github.com/ansforge/IG-fhir-annuaire/pull/198), [196](https://github.com/ansforge/IG-fhir-annuaire/pull/196), [174](https://github.com/ansforge/IG-fhir-annuaire/pull/174), [169](https://github.com/ansforge/IG-fhir-annuaire/pull/169), [167](https://github.com/ansforge/IG-fhir-annuaire/pull/167)
+* (1.0.0-ballot-4) CS update [189](https://github.com/ansforge/IG-fhir-annuaire/pull/189).
+* (1.0.0-ballot-4) Various fixes [186](https://github.com/ansforge/IG-fhir-annuaire/pull/186), [181](https://github.com/ansforge/IG-fhir-annuaire/pull/181), [176](https://github.com/ansforge/IG-fhir-annuaire/pull/176), [190](https://github.com/ansforge/IG-fhir-annuaire/pull/190), [166](https://github.com/ansforge/IG-fhir-annuaire/pull/166)
+* (1.0.0-ballot-4) SP update [184](https://github.com/ansforge/IG-fhir-annuaire/pull/184)
+
+* (1.0.0-ballot-3) Profiling of the Person resource: Person (definition of the professional as a natural person) → Practitioner (professional practice) → PractitionerRole (practice situation) [121](https://github.com/ansforge/IG-fhir-annuaire/pull/121)
+* (1.0.0-ballot-3) Addition of NOS as dependency [149](https://github.com/ansforge/IG-fhir-annuaire/pull/149)
+* (1.0.0-ballot-3) Addition of PlantUML diagrams [148](https://github.com/ansforge/IG-fhir-annuaire/pull/148)
+* (1.0.0-ballot-3) Automatic generation of profile lists [145](https://github.com/ansforge/IG-fhir-annuaire/pull/145)
+* (1.0.0-ballot-3) Addition of supplementary FINESS data [139](https://github.com/ansforge/IG-fhir-annuaire/pull/139)

--- a/input/translations/en/pagecontent/downloads.md
+++ b/input/translations/en/pagecontent/downloads.md
@@ -1,0 +1,14 @@
+The implementation guide contains a package [downloadable here](package.tgz) that can be used to validate instances against the profiles it contains.
+
+To do so, download the [package.tgz](package.tgz) and import it into a server — for example on HAPI using this open-source [Python script](https://github.com/nmdp-bioinformatics/igloader).
+
+You can then use the [$validate](https://www.hl7.org/fhir/resource-operation-validate.html) operation to validate resource instances against a profile from this specification.
+
+All downloadable resources:
+
+* [Full specification (zip)](full-ig.zip)
+* [Package (tgz)](package.tgz)
+* [JSON Definitions (zip)](definitions.json.zip)
+* [JSON Examples (zip)](examples.json.zip)
+* [XML Definitions (zip)](definitions.xml.zip)
+* [XML Examples (zip)](examples.xml.zip)

--- a/input/translations/en/pagecontent/index.md
+++ b/input/translations/en/pagecontent/index.md
@@ -1,0 +1,66 @@
+### Introduction
+
+<p style="padding: 5px; border-radius: 5px; border: 2px solid maroon; background: #ffffe6; width: 65%">
+<b>Healthcare professional Directory Implementation Guide</b><br>
+This implementation guide contains the FHIR profiles of French Healthcare professionals directory and documents how the data are exposed in the national API.
+</p>
+
+
+{% if site.data.info.releaselabel == 'ci-build' %}
+<div style="width: 65%">
+<blockquote class="stu-note">
+<p>
+  <b>Warning!</b> This version of the implementation guide is in continuous integration (working version) and is subject to regular changes. The official version is available at https://interop.esante.gouv.fr/ig/fhir/annuaire</b>
+</p>
+</blockquote>
+</div>
+{% endif %}
+
+The objective of this guide is to present the FHIR modelling of data from the Annuaire Santé, in compliance with the FHIR interoperability standard. This implementation guide has two objectives:
+<div class="wysiwyg" markdown="1">
+- Present the data published by the Annuaire Santé national FHIR API
+- Serve as a foundation for the FHIR modelling of health professionals in France (cf. generic profiles)
+</div>
+This implementation guide is a specification that focuses primarily on the data model, not on the technical solution of the Annuaire Santé FHIR API. For more information on how the API works, please consult [the dedicated FHIR API documentation](https://ansforge.github.io/annuaire-sante-fhir-documentation)
+
+#### Project context
+
+The [Annuaire Santé](https://esante.gouv.fr/produits-services/annuaire-sante) brings together the reference sectoral directories for natural persons and legal entities: the shared directory of professionals involved in the healthcare system (RPPS+), and the FINESS+ directory. The Annuaire Santé is a professional-use service intended for actors in the health, social, and medico-social sectors. This publication service also provides data from MSSanté operators, the SI CPX, and the Assurance Maladie.
+
+The Annuaire Santé FHIR API is a RESTful API in JSON format, structured according to the FHIR interoperability standard.
+
+##### Profiled resources
+
+<div class="figure" style="width:100%;">
+    <p>{% include document-overview.svg %}</p>
+</div>
+
+The list below shows the generic profiles. These have been re-profiled to specify the public data and restricted data APIs. These profiles can be found in the "list of profiles" tab.
+
+{% sql SELECT '[' || Title ||'](StructureDefinition-' || id || '.html)' as "Profile title", Description, json_extract(Json, '$.baseDefinition') as "Parent profile canonical URL" FROM Resources WHERE Type = 'StructureDefinition' and Description like "Profil générique%" %}
+<!-- like "%Profil%" added to avoid error if empty -->
+
+##### Standards used
+
+These technical specifications are based on the HL7 FHIR Release 4 (R4) standard. They reference a number of standard resources as well as the FHIR REST API specifications, based on the HTTP protocol. The syntax used is JSON format.
+
+The diagram below maps the following two concepts: the "Modèle des Objets de Santé" [(MOS)](https://esante.gouv.fr/produits-services/mos-nos) managed by ANS, and the HL7 FHIR resource concept.
+
+<div class="figure" style="width:100%;">
+    <img style="height: auto; width: 100%;" src="mappingFHIRAnnuaireSante.png" alt="mapping fhir annuaire" title="mapping fhir annuaire">
+</div>
+
+#### Useful links
+
+* [Annuaire Santé FHIR API documentation (open access)](https://ansforge.github.io/annuaire-sante-fhir-documentation/)
+* [Demo portal](https://portail.openfhir.annuaire.sante.fr/)
+
+### Note
+
+The examples associated with the profiles in this guide are provided for informational purposes and may evolve over time. They are not to be taken as a normative reference.
+
+Attributes marked with the MustSupport tag are used by the Annuaire Santé API. These tags are only used in the context of applicative profiles.
+
+### Dependencies
+
+{% include dependency-table.xhtml %}

--- a/input/translations/en/pagecontent/liste_profils.md
+++ b/input/translations/en/pagecontent/liste_profils.md
@@ -1,0 +1,42 @@
+The profiles specify the data format exposed by the Annuaire API. Some fields carry a Must Support (MS) tag, symbolised by an S enclosed in a red square, indicating that this data is exposed by the API when it exists.
+
+### List of generic profiles
+
+These generic profiles have no strong constraints so that they can be easily inherited by other guides, such as CI-SIS volumes. These constraints may be progressively reused within the InteropSanté profiles.
+These profiles inherit from base FHIR resources or from InteropSanté profiles.
+
+
+{% sql {
+    "query" : " select name as Name, Description, Web from Resources WHERE Type = 'StructureDefinition' and Description like 'Profil générique%' ",
+    "class" : "lines",
+    "columns" : [
+        { "title" : "Profile title", "type" : "link", "source" : "Name", "target" : "Web"},
+        { "title" : "Description", "type" : "markdown", "source" : "Description"}
+    ]
+} %}
+
+### List of applicative profiles — public data
+
+List of applicative profiles inheriting from generic profiles, detailing the resources exposed through open access by the public data API.
+
+{% sql {
+    "query" : " select name as Name, Description, Web from Resources WHERE Type = 'StructureDefinition' and Description like 'Profil public%' ",
+    "class" : "lines",
+    "columns" : [
+        { "title" : "Profile title", "type" : "link", "source" : "Name", "target" : "Web"},
+        { "title" : "Description", "type" : "markdown", "source" : "Description"}
+    ]
+} %}
+
+### List of applicative profiles — restricted data
+
+List of applicative profiles inheriting from generic profiles, detailing the resources exposed through restricted access.
+
+{% sql {
+    "query" : " select name as Name, Description, Web from Resources WHERE Type = 'StructureDefinition' and Description like 'Profil restreint%' ",
+    "class" : "lines",
+    "columns" : [
+        { "title" : "Profile title", "type" : "link", "source" : "Name", "target" : "Web"},
+        { "title" : "Description", "type" : "markdown", "source" : "Description"}
+    ]
+} %}

--- a/input/translations/en/pagecontent/problematiques_connues.md
+++ b/input/translations/en/pagecontent/problematiques_connues.md
@@ -1,0 +1,10 @@
+### AsDeviceProfile
+
+The AsDeviceProfile has a generic name even though it is specific to heavy medical equipment (EML — Équipements Matériels Lourds). For example, a Device resource could relate to a pacemaker, which falls outside the scope of the Annuaire Santé use case.
+
+Two options are currently under consideration:
+
+* Remove the generic AsDeviceProfile while keeping the dp and dr profiles
+* Rename the profile to AsDeviceEMLProfile, AsDeviceHeavyEquipmentProfile, or similar
+
+This work will be addressed as part of the FINESS+ model evolution.

--- a/input/translations/en/pagecontent/securite.md
+++ b/input/translations/en/pagecontent/securite.md
@@ -1,0 +1,7 @@
+### Security
+
+The data carried through these flows are personal data, including sensitive medical data that must be protected.
+
+This section presents any security recommendations that apply to this implementation guide. It constitutes a subset, related to the interoperability dimension, of broader security measures aimed at covering the security requirements of a target system.
+
+It is the responsibility of the data controller of the target system to implement security measures appropriate to their risk analysis for the service. Depending on their security policy, they may choose whether or not to implement the specific measures described in this section. The security frameworks published by ANS provide recommendations on this subject.

--- a/input/translations/en/pagecontent/tests.md
+++ b/input/translations/en/pagecontent/tests.md
@@ -1,0 +1,31 @@
+### Presentation
+
+<div style="text-align: center;">{%include tests.svg%}</div>
+
+#### Testing environment
+
+This tool allows conformance validation of:
+- CDA documents
+- IHE_XDM.ZIP archives used for exchanges
+- FHIR resources
+- .....
+
+
+It is accessible online:
+- [https://interop.esante.gouv.fr/](https://interop.esante.gouv.fr/)
+
+It is notably used during Projectathons organised by ANS for software vendors.
+
+
+#### HAPI FHIR
+
+This method is particularly useful during the modelling phase of new profiles, or when creating examples.
+
+A full description is available via the link below:
+-   [https://github.com/ansforge/FIG_ans-ig-sample/wiki/Valider-une-ressource-contre-un-profil](https://github.com/ansforge/FIG_ans-ig-sample/wiki/Valider-une-ressource-contre-un-profil)
+
+### Projectathon
+
+ANS regularly organises Projectathons to allow vendors to verify the conformance of their implementation of interoperability specifications and to carry out interoperability tests with other vendors.
+
+You will be notified by ANS of upcoming Projectathons (date, location, etc.) so that you can participate.

--- a/input/translations/en/pagecontent/translationinfo.md
+++ b/input/translations/en/pagecontent/translationinfo.md
@@ -1,0 +1,5 @@
+### Translation Information
+
+This implementation guide is written in French. The French version is the official authoritative reference.
+
+An English translation is provided for informational purposes. This translation was generated automatically by artificial intelligence and has not been reviewed by the authors of the guide. In the event of any discrepancy between the French and English versions, the French version prevails.


### PR DESCRIPTION
## Description des changements

* Ajout des fichiers de traduction anglaise dans `input/translations/en/pagecontent/` pour les 8 pages du guide (index, liste_profils, downloads, securite, tests, problematiques_connues, changes, translationinfo)
* Mise à jour de `input/pagecontent/translationinfo.md` (FR) : mention que la version française fait foi et que la traduction est automatique

## Type de changement

- [x] Nouveau contenu (profil, extension, page, exemple)

## Checklist

- [x] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour
- [x] La branche est à jour avec `main`

## Note sur la traduction

La traduction a été générée automatiquement par IA (Claude, Anthropic). Elle n'a pas été relue par les auteurs du guide. **La version française fait foi.** En cas de divergence entre les deux versions, la version française prévaut. Cette mention est explicite dans la page `translationinfo`.

## Preview

https://ansforge.github.io/IG-fhir-annuaire/nr-translate-en/ig