### PR TITLE
test: benchmark workflow sans image Docker

### DIFF
--- a/.github/workflows/fhir-worklows.yml
+++ b/.github/workflows/fhir-worklows.yml
@@ -11,12 +11,13 @@ jobs:
       - uses: actions/checkout@v3
         with:      
           path: igSource
-      - uses: ansforge/IG-workflows@main
-        with:      
-          repo_ig: "./igSource"   
+      - uses: ansforge/IG-workflows@docker-image-optimization
+        with:
+          repo_ig: "./igSource"
           github_page: "true"
           github_page_token: ${{ secrets.GITHUB_TOKEN }}
           bake: "false"
           validator_cli: "false"
           generate_testscript: "false"
           generate_plantuml : "false"
+          use_docker_image: "false"


### PR DESCRIPTION
Benchmark de référence — pointe sur `ansforge/IG-workflows@docker-image-optimization` avec `use_docker_image: false` (comportement actuel, installation des outils à chaque run).