### PR TITLE
test: benchmark workflow avec image Docker

### DIFF
--- a/.github/workflows/fhir-worklows.yml
+++ b/.github/workflows/fhir-worklows.yml
@@ -11,12 +11,13 @@ jobs:
       - uses: actions/checkout@v3
         with:      
           path: igSource
-      - uses: ansforge/IG-workflows@main
-        with:      
-          repo_ig: "./igSource"   
+      - uses: ansforge/IG-workflows@docker-image-optimization
+        with:
+          repo_ig: "./igSource"
           github_page: "true"
           github_page_token: ${{ secrets.GITHUB_TOKEN }}
           bake: "false"
           validator_cli: "false"
           generate_testscript: "false"
           generate_plantuml : "false"
+          use_docker_image: "false"

--- a/.github/workflows/fhir-worklows.yml
+++ b/.github/workflows/fhir-worklows.yml
@@ -20,4 +20,4 @@ jobs:
           validator_cli: "false"
           generate_testscript: "false"
           generate_plantuml : "false"
-          use_docker_image: "false"
+          use_docker_image: "true"


### PR DESCRIPTION
Benchmark avec optimisation — pointe sur `ansforge/IG-workflows@docker-image-optimization` avec `use_docker_image: true` (image `ghcr.io/ansforge/fhir-ig-builder:latest` + cache JARs).