### PR TITLE
fix: lieu de formation en CodeableConcept lié à JDV-J235-LieuFormation-EPARS

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -41,6 +41,7 @@ Alias: $JDV-J130-CNAMAmeliSecteurConventionnement-RASS = https://mos.esante.gouv
 Alias: $JDV-J86-NatCycleForm-RASS = https://mos.esante.gouv.fr/NOS/JDV_J86-NatCycleForm-RASS/FHIR/JDV-J86-NatCycleForm-RASS
 Alias: $JDV-J87-NiveauFormAcquis-RASS = https://mos.esante.gouv.fr/NOS/JDV_J87-NiveauFormAcquis-RASS/FHIR/JDV-J87-NiveauFormAcquis-RASS
 Alias: $JDV-J88-AnneeUniversitaire-RASS = https://mos.esante.gouv.fr/NOS/JDV_J88-AnneeUniversitaire-RASS/FHIR/JDV-J88-AnneeUniversitaire-RASS
+Alias: $JDV-J235-LieuFormation-EPARS = https://mos.esante.gouv.fr/NOS/JDV_J235-LieuFormation-EPARS/FHIR/JDV-J235-LieuFormation-EPARS
 Alias: $JDV-J92-MotifFinActivite-RASS = https://mos.esante.gouv.fr/NOS/JDV_J92-MotifFinActivite-RASS/FHIR/JDV-J92-MotifFinActivite-RASS
 Alias: $JDV-J93-RegionOM-RASS = https://mos.esante.gouv.fr/NOS/JDV_J93-RegionOM-RASS/FHIR/JDV-J93-RegionOM-RASS
 Alias: $JDV-J83-AutoriteEnregistrement-RASS = https://mos.esante.gouv.fr/NOS/JDV_J83-AutoriteEnregistrement-RASS/FHIR/JDV-J83-AutoriteEnregistrement-RASS

--- a/input/fsh/extensions/AsEducationLevelExtension.fsh
+++ b/input/fsh/extensions/AsEducationLevelExtension.fsh
@@ -16,8 +16,9 @@ Description: 	"Extension créée dans le cadre de l'Annuaire Santé pour décrir
 * extension contains
     academicDegree 0..1 and
     achievedLevel 0..1 and
-    academicYear 0..1 
-    
+    academicYear 0..1 and
+    trainingLocation 0..1
+
 // natureCycleFormation
 * extension[academicDegree] ^short = "[Donnée restreinte] : Nature du cycle de formation (natureCycleFormation)."
 * extension[academicDegree].value[x] only CodeableConcept
@@ -32,4 +33,9 @@ Description: 	"Extension créée dans le cadre de l'Annuaire Santé pour décrir
 * extension[academicYear] ^short = "[Donnée restreinte] : Année universitaire du professionnel (anneeUniversitaire).\nExemple : 2015-2016."
 * extension[academicYear].value[x] only CodeableConcept
 * extension[academicYear].valueCodeableConcept from $JDV-J88-AnneeUniversitaire-RASS (required)
+
+// lieuFormation
+* extension[trainingLocation] ^short = "[Donnée restreinte] : Type de lieu ayant délivré le diplôme (lieuFormation)."
+* extension[trainingLocation].value[x] only CodeableConcept
+* extension[trainingLocation].valueCodeableConcept from $JDV-J235-LieuFormation-EPARS (required)
 

--- a/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
+++ b/input/fsh/profiles-dp/AsDpPractitionerProfile.fsh
@@ -60,8 +60,7 @@ Description: 	"""Profil public applicatif créé à partir du profil générique
 // qualification - Donnees restreintes
 * qualification.period 0..0
 
-* qualification[degree].issuer 0..0
-* qualification[degree].extension[as-ext-education-level] 0..0 
+* qualification[degree].extension[as-ext-education-level] 0..0
 
 * qualification[savoirFaire].code.coding[savoirFaire] ^short = "Compétence acquise par le professionnel (competence) R39 ou Compétence exclusive exercée par le professionnel à titre exclusif (competenceExclusive) R40 ou Diplôme d'études spécialisées complémentaires (DESC)DESCnonQualifian R42 ou Capacité (savoir-faire)de médecine (capaciteSavoirFaire) R43 ou Qualification de praticien adjoint contractuel (qualificationPAC) R44 ou Fonction qualifiée (Synonyme: fonctionQualifiee) R45 ou Droit d'exercice complémentaire (Synonyme: droitExerciceComplementaire) R97."
 

--- a/input/fsh/profiles/AsPractitionerProfile.fsh
+++ b/input/fsh/profiles/AsPractitionerProfile.fsh
@@ -89,11 +89,11 @@ Description: 	"Profil générique créé à partir de FrPractitioner dans le con
 * qualification[degree].period.end ^short = "dateFin : Date à laquelle le niveau de formation n’est plus actif (non visible hormis dans les données historisées)."
 
 // lieuFormation
-* qualification[degree].issuer ^short = "[Donnée restreinte] : Lieu de formation pour l'obtention du diplôme (lieuFormation)."
-* qualification[degree].issuer only Reference(AsOrganizationProfile or fr-core-organization)
+* qualification[degree].issuer 0..0
 
 //
 * qualification[degree].extension contains AsEducationLevelExtension named as-ext-education-level 0..* MS
+* qualification[degree].extension[as-ext-education-level].extension[trainingLocation] MS
 
 // ##############
 // # PROFESSION #
@@ -170,12 +170,12 @@ Title:    "AsPractitionerProfile to MOS - Diplome"
 * -> "Diplome"
 * qualification.code -> "Diplome.codeDiplome"
 * qualification[degree] -> "Diplome.typeDiplome"
-* qualification[degree].issuer -> "Diplome.lieuFormation"
 * qualification[degree].period.start -> "Diplome.dateDebut"
 * qualification[degree].period.end -> "Diplome.dateFin"
 * qualification[degree].extension[as-ext-education-level].extension[academicDegree] -> "Diplome.natureCycleFormation"
 * qualification[degree].extension[as-ext-education-level].extension[achievedLevel] -> "Diplome.anneeUniversitaire"
 * qualification[degree].extension[as-ext-education-level].extension[academicYear] -> "Diplome.niveauFormationAcquis"
+* qualification[degree].extension[as-ext-education-level].extension[trainingLocation] -> "Diplome.lieuFormation"
 
 Mapping:  AsPractitionerProfileToMOSProfessionnel
 Source:   AsPractitionerProfile

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -2,6 +2,7 @@
 
 #### 1.2.0-snapshot-2
 
+* Passage du lieu de formation (qualification.issuer) en CodeableConcept plutôt qu'en Reference vers Organization, binding JDV-J235-LieuFormation-EPARS (issue #314) [#PR_NUMBER](https://github.com/ansforge/IG-fhir-annuaire/pull/PR_NUMBER)
 * Mise à jour de la dépendance FRCore vers 2.2.0 (correction issue #289, héritage fr-core-organization-etablissement, suppression ADELI) [#307](https://github.com/ansforge/IG-fhir-annuaire/pull/307)
 * Suppression du profil G13 des données publiques [#304](https://github.com/ansforge/IG-fhir-annuaire/pull/304)
 * BAL MSSanté : ajout Swagger et préférence BAL [#306](https://github.com/ansforge/IG-fhir-annuaire/pull/306)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -2,7 +2,7 @@
 
 #### 1.2.0-snapshot-2
 
-* Passage du lieu de formation (qualification.issuer) en CodeableConcept plutôt qu'en Reference vers Organization, binding JDV-J235-LieuFormation-EPARS (issue #314) [#PR_NUMBER](https://github.com/ansforge/IG-fhir-annuaire/pull/PR_NUMBER)
+* Passage du lieu de formation (qualification.issuer) en CodeableConcept plutôt qu'en Reference vers Organization, binding JDV-J235-LieuFormation-EPARS (issue #314) [#315](https://github.com/ansforge/IG-fhir-annuaire/pull/315)
 * Mise à jour de la dépendance FRCore vers 2.2.0 (correction issue #289, héritage fr-core-organization-etablissement, suppression ADELI) [#307](https://github.com/ansforge/IG-fhir-annuaire/pull/307)
 * Suppression du profil G13 des données publiques [#304](https://github.com/ansforge/IG-fhir-annuaire/pull/304)
 * BAL MSSanté : ajout Swagger et préférence BAL [#306](https://github.com/ansforge/IG-fhir-annuaire/pull/306)


### PR DESCRIPTION
## Description des changements

* Passage de `Practitioner.qualification[degree].issuer` (Reference vers Organization) à une sous-extension CodeableConcept `trainingLocation` dans `AsEducationLevelExtension`, bindée sur le JDV confirmé par @zilliw dans l'issue.
* Ajout de l'alias `$JDV-J235-LieuFormation-EPARS` dans `input/fsh/aliases.fsh`.
* `qualification[degree].issuer` passe à `0..0` dans `AsPractitionerProfile` (suppression de la ligne devenue redondante dans `AsDpPractitionerProfile`, déjà couverte par la neutralisation de toute l'extension `as-ext-education-level`).
* Mise à jour du mapping MOS `Diplome.lieuFormation` vers le nouveau chemin d'extension.
* Mise à jour de `change-log.md` (changes.md).

Closes #314

## Preview

https://build.fhir.org/ig/ansforge/IG-fhir-annuaire/branches/nr-314-lieu-formation

https://ansforge.github.io/IG-fhir-annuaire/nr-314-lieu-formation/ig/